### PR TITLE
feat: 챗봇 세션 및 메시지 관리 기능 구현

### DIFF
--- a/src/main/java/org/scoula/chatbot/controller/ChatBotApiController.java
+++ b/src/main/java/org/scoula/chatbot/controller/ChatBotApiController.java
@@ -29,4 +29,14 @@ public class ChatBotApiController {
         ChatSession session = sessionManager.createSession(sessionId);
         return ApiResponse.success(ResponseCode.CHATBOT_SESSION_CREATED, sessionId);
     }
+    @PostMapping("/message")
+    public ApiResponse<?> sendMessage(@RequestParam String sessionId, @RequestParam String userMessage) {
+        ChatSession session = sessionManager.getSession(sessionId);
+        if(session == null) return ApiResponse.fail(ResponseCode.CHATGPT_JSON_PARSING_FAILED);
+        session.addMessage(new ChatMessage("user", userMessage));
+
+        String response = chatGptService.summarize(session.getMessages());
+        session.addMessage(new ChatMessage("assistant", response));
+        return ApiResponse.success(ResponseCode.CHATBOT_RESPONSE_SUCCESS, response);
+    }
 }

--- a/src/main/java/org/scoula/chatbot/controller/ChatBotApiController.java
+++ b/src/main/java/org/scoula/chatbot/controller/ChatBotApiController.java
@@ -1,0 +1,32 @@
+package org.scoula.chatbot.controller;
+
+import io.swagger.annotations.Api;
+import org.scoula.chatbot.session.ChatSession;
+import org.scoula.chatbot.session.ChatSessionManager;
+import org.scoula.chatgpt.dto.gpt.ChatMessage;
+import org.scoula.chatgpt.service.ChatGptService;
+import org.scoula.response.ApiResponse;
+import org.scoula.response.ResponseCode;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/chatbot")
+public class ChatBotApiController {
+    private final ChatGptService chatGptService;
+    private final ChatSessionManager sessionManager;
+
+    public ChatBotApiController(ChatGptService chatGptService, ChatSessionManager sessionManager) {
+        this.chatGptService = chatGptService;
+        this.sessionManager = sessionManager;
+    }
+
+    @PostMapping("/session")
+    public ApiResponse<?> startSession(@RequestParam String sessionId) {
+        ChatSession session = sessionManager.createSession(sessionId);
+        return ApiResponse.success(ResponseCode.CHATBOT_SESSION_CREATED, sessionId);
+    }
+}

--- a/src/main/java/org/scoula/chatbot/controller/ChatBotApiController.java
+++ b/src/main/java/org/scoula/chatbot/controller/ChatBotApiController.java
@@ -1,47 +1,82 @@
 package org.scoula.chatbot.controller;
 
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import java.util.List;
 import org.scoula.chatbot.session.ChatSession;
 import org.scoula.chatbot.session.ChatSessionManager;
 import org.scoula.chatgpt.dto.gpt.ChatMessage;
 import org.scoula.chatgpt.service.ChatGptService;
 import org.scoula.response.ApiResponse;
 import org.scoula.response.ResponseCode;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/chatbot")
+@Api(tags = "ChatBot API", description = "ChatGPT 기반 챗봇 세션 및 메시지 전송 API")
 public class ChatBotApiController {
+
     private final ChatGptService chatGptService;
     private final ChatSessionManager sessionManager;
+
+    @Value("${chatgpt.chatbot-prompt}")
+    private String chatbotPrompt;
 
     public ChatBotApiController(ChatGptService chatGptService, ChatSessionManager sessionManager) {
         this.chatGptService = chatGptService;
         this.sessionManager = sessionManager;
     }
 
+    @ApiOperation(
+            value = "챗봇 세션 생성",
+            notes = "새로운 챗봇 세션을 생성합니다. sessionId는 클라이언트가 지정합니다."
+    )
     @PostMapping("/session")
-    public ApiResponse<?> startSession(@RequestParam String sessionId) {
+    public ApiResponse<?> startSession(
+            @ApiParam(value = "클라이언트가 지정한 세션 ID", required = true)
+            @RequestParam String sessionId
+    ) {
         ChatSession session = sessionManager.createSession(sessionId);
         return ApiResponse.success(ResponseCode.CHATBOT_SESSION_CREATED, sessionId);
     }
-    @PostMapping("/message")
-    public ApiResponse<?> sendMessage(@RequestParam String sessionId, @RequestParam String userMessage) {
+
+    @ApiOperation(
+            value = "챗봇 메시지 전송",
+            notes = "지정된 세션에 사용자의 메시지를 전송하고, GPT의 응답을 반환합니다."
+    )
+    @PostMapping("/message") public ApiResponse<?> sendMessage(
+            @ApiParam(value = "세션 ID", required = true, example = "session123")
+            @RequestParam String sessionId,
+
+            @ApiParam(value = "사용자 메시지", required = true, example = "ISA 계좌가 뭐야?")
+            @RequestParam String userMessage
+    ) {
         ChatSession session = sessionManager.getSession(sessionId);
-        if(session == null) return ApiResponse.fail(ResponseCode.CHATGPT_JSON_PARSING_FAILED);
+        if (session == null)
+            return ApiResponse.fail(ResponseCode.CHATGPT_JSON_PARSING_FAILED);
+
         session.addMessage(new ChatMessage("user", userMessage));
 
-        String response = chatGptService.summarize(session.getMessages());
+        String content = chatbotPrompt + "\n\n" + userMessage;
+        List<ChatMessage> messages = session.getMessages();
+        messages.add(0, new ChatMessage("system", chatbotPrompt)); // 프롬프트는 최상단에 1회만
+
+        String response = chatGptService.chat(messages);
+
         session.addMessage(new ChatMessage("assistant", response));
         return ApiResponse.success(ResponseCode.CHATBOT_RESPONSE_SUCCESS, response);
     }
 
+    @ApiOperation(
+            value = "챗봇 세션 종료",
+            notes = "지정된 세션 ID의 챗봇 세션을 종료합니다."
+    )
     @DeleteMapping("/session")
-    public ApiResponse<?> endSession(@RequestParam String sessionId) {
+    public ApiResponse<?> endSession(
+            @ApiParam(value = "세션 ID", required = true) @RequestParam String sessionId
+    ) {
         sessionManager.removeSession(sessionId);
         return ApiResponse.success(ResponseCode.CHATBOT_SESSION_TERMINATED);
     }

--- a/src/main/java/org/scoula/chatbot/controller/ChatBotApiController.java
+++ b/src/main/java/org/scoula/chatbot/controller/ChatBotApiController.java
@@ -39,4 +39,10 @@ public class ChatBotApiController {
         session.addMessage(new ChatMessage("assistant", response));
         return ApiResponse.success(ResponseCode.CHATBOT_RESPONSE_SUCCESS, response);
     }
+
+    @DeleteMapping("/session")
+    public ApiResponse<?> endSession(@RequestParam String sessionId) {
+        sessionManager.removeSession(sessionId);
+        return ApiResponse.success(ResponseCode.CHATBOT_SESSION_TERMINATED);
+    }
 }

--- a/src/main/java/org/scoula/chatbot/session/ChatSession.java
+++ b/src/main/java/org/scoula/chatbot/session/ChatSession.java
@@ -7,13 +7,25 @@ import org.scoula.chatgpt.dto.gpt.ChatMessage;
 public class ChatSession {
     private String sessionId;
     private List<ChatMessage> messages = new ArrayList<>();
+    private long lastAccessTime;
 
     public ChatSession(String sessionId) {
         this.sessionId = sessionId;
+        this.messages = new ArrayList<>();
+        this.lastAccessTime = System.currentTimeMillis();
+    }
+
+    public void updateLastAccessTime() {
+        this.lastAccessTime = System.currentTimeMillis();
+    }
+
+    public long getLastAccessTime() {
+        return lastAccessTime;
     }
 
     public void addMessage(ChatMessage message) {
         messages.add(message);
+        updateLastAccessTime();
     }
 
     public List<ChatMessage> getMessages() {

--- a/src/main/java/org/scoula/chatbot/session/ChatSession.java
+++ b/src/main/java/org/scoula/chatbot/session/ChatSession.java
@@ -1,0 +1,22 @@
+package org.scoula.chatbot.session;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.scoula.chatgpt.dto.gpt.ChatMessage;
+
+public class ChatSession {
+    private String sessionId;
+    private List<ChatMessage> messages = new ArrayList<>();
+
+    public ChatSession(String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public void addMessage(ChatMessage message) {
+        messages.add(message);
+    }
+
+    public List<ChatMessage> getMessages() {
+        return messages;
+    }
+}

--- a/src/main/java/org/scoula/chatbot/session/ChatSessionManager.java
+++ b/src/main/java/org/scoula/chatbot/session/ChatSessionManager.java
@@ -6,19 +6,34 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class ChatSessionManager {
-    private final Map<String, ChatSession> sessionStore = new ConcurrentHashMap<>();
+    private Map<String, ChatSession> sessions = new ConcurrentHashMap<>();
+    private final long sessionTimeoutMillis = 30 * 60 * 1000; // 30분
+//    private final long sessionTimeoutMillis = 1 * 60 * 1000; // 1분
 
     public ChatSession createSession(String sessionId) {
         ChatSession session = new ChatSession(sessionId);
-        sessionStore.put(sessionId, session);
+        sessions.put(sessionId, session);
         return session;
     }
 
     public ChatSession getSession(String sessionId) {
-        return sessionStore.get(sessionId);
+        ChatSession session = sessions.get(sessionId);
+        if (session == null) return null;
+
+        long now = System.currentTimeMillis();
+        if (now - session.getLastAccessTime() > sessionTimeoutMillis) {
+            sessions.remove(sessionId);
+            return null;
+        }
+        return session;
     }
 
     public void removeSession(String sessionId) {
-        sessionStore.remove(sessionId);
+        sessions.remove(sessionId);
+    }
+
+    public void cleanupExpiredSessions() {
+        long now = System.currentTimeMillis();
+        sessions.entrySet().removeIf(entry -> now - entry.getValue().getLastAccessTime() > sessionTimeoutMillis);
     }
 }

--- a/src/main/java/org/scoula/chatbot/session/ChatSessionManager.java
+++ b/src/main/java/org/scoula/chatbot/session/ChatSessionManager.java
@@ -1,0 +1,24 @@
+package org.scoula.chatbot.session;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChatSessionManager {
+    private final Map<String, ChatSession> sessionStore = new ConcurrentHashMap<>();
+
+    public ChatSession createSession(String sessionId) {
+        ChatSession session = new ChatSession(sessionId);
+        sessionStore.put(sessionId, session);
+        return session;
+    }
+
+    public ChatSession getSession(String sessionId) {
+        return sessionStore.get(sessionId);
+    }
+
+    public void removeSession(String sessionId) {
+        sessionStore.remove(sessionId);
+    }
+}

--- a/src/main/java/org/scoula/chatbot/session/SessionCleanupScheduler.java
+++ b/src/main/java/org/scoula/chatbot/session/SessionCleanupScheduler.java
@@ -1,0 +1,19 @@
+package org.scoula.chatbot.session;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SessionCleanupScheduler {
+
+    private final ChatSessionManager sessionManager;
+
+    public SessionCleanupScheduler(ChatSessionManager sessionManager) {
+        this.sessionManager = sessionManager;
+    }
+
+    @Scheduled(fixedRate = 10 * 60 * 1000)
+    public void cleanup() {
+        sessionManager.cleanupExpiredSessions();
+    }
+}

--- a/src/main/java/org/scoula/chatgpt/controller/ChatGptController.java
+++ b/src/main/java/org/scoula/chatgpt/controller/ChatGptController.java
@@ -49,9 +49,6 @@ public class ChatGptController {
             sb.append(product.toString()).append("\n\n");
         }
         sb.append(comparePrompt);
-        System.out.println("====================");
-        System.out.println(sb.toString());
-        System.out.println("====================");
         String response = chatGptService.compare(List.of(new ChatMessage(sb.toString())));
         return ApiResponse.success(ResponseCode.CHATGPT_COMPARE_SUCCESS, response);
     }

--- a/src/main/java/org/scoula/chatgpt/service/ChatGptService.java
+++ b/src/main/java/org/scoula/chatgpt/service/ChatGptService.java
@@ -33,6 +33,10 @@ public class ChatGptService {
         return chatGptUtil.createChatCompletion(toChatCompletionRequest(messages), API_URL);
     }
 
+    public String chat(List<ChatMessage> messages) {
+        return chatGptUtil.createChatCompletion(toChatCompletionRequest(messages), API_URL);
+    }
+
     public ChatCompletionRequest toChatCompletionRequest(List<ChatMessage> messages) {
         return new ChatCompletionRequest(model, messages, maxTokens);
     }

--- a/src/main/java/org/scoula/chatgpt/util/ChatGptUtil.java
+++ b/src/main/java/org/scoula/chatgpt/util/ChatGptUtil.java
@@ -44,7 +44,6 @@ public class ChatGptUtil {
         try {
             HttpResponse<String> response = client.send(request,
                     BodyHandlers.ofString(StandardCharsets.UTF_8));
-            System.out.println("OpenAI API response body: " + response.body());
             if (response.statusCode() != 200) {
                 log.error("OpenAI 응답 실패: {}", response.body());
                 throw new ChatGptRetrievalException(ResponseCode.CHATGPT_RETRIEVAL_FAILED);

--- a/src/main/java/org/scoula/common/config/ServletConfig.java
+++ b/src/main/java/org/scoula/common/config/ServletConfig.java
@@ -19,7 +19,7 @@ import org.springframework.web.servlet.view.JstlView;
         "org.scoula.chatgpt.controller",
         "org.scoula.chatgpt.service",
         "org.scoula.chatbot.controller",
-        "org.scoula.chatbot.session"
+        "org.scoula.chatbot.session",
 }) // Spring MVC용 컴포넌트 등록을 위한 스캔 패키지
 public class ServletConfig implements WebMvcConfigurer {
 

--- a/src/main/java/org/scoula/common/config/ServletConfig.java
+++ b/src/main/java/org/scoula/common/config/ServletConfig.java
@@ -17,7 +17,9 @@ import org.springframework.web.servlet.view.JstlView;
 @ComponentScan(basePackages = {
         "org.scoula.common.exception",
         "org.scoula.chatgpt.controller",
-        "org.scoula.chatgpt.service"
+        "org.scoula.chatgpt.service",
+        "org.scoula.chatbot.controller",
+        "org.scoula.chatbot.session"
 }) // Spring MVC용 컴포넌트 등록을 위한 스캔 패키지
 public class ServletConfig implements WebMvcConfigurer {
 

--- a/src/main/java/org/scoula/response/ResponseCode.java
+++ b/src/main/java/org/scoula/response/ResponseCode.java
@@ -9,6 +9,14 @@ public enum ResponseCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다,"),
 
     /**
+     *  ChatBot response
+     */
+    CHATBOT_SESSION_CREATED(HttpStatus.OK, "챗봇 세션이 생성되었습니다."),
+    CHATBOT_RESPONSE_SUCCESS(HttpStatus.OK, "응답 생성 완료"),
+    CHATBOT_SESSION_TERMINATED(HttpStatus.OK, "세션 종료 완료"),
+    CHATBOT_SESSION_RESTORED(HttpStatus.OK, "세션이 복원되었습니다."),
+    CHATBOT_HISTORY_ROLLED_BACK(HttpStatus.OK, "대화 히스토리 롤백 완료"),
+    /**
      * ChatGPT response
      */
     CHATGPT_SUMMARY_SUCCESS(HttpStatus.OK, "상품 요약이 처리되었습니다."),


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close: #7 

---

## 🪄 작업 내용

- 세션 생성 API 구현
- 세션 종료 API 구현
- 메시지 전송 시 금융 관련 질문만 응답하도록 프롬프트 설계 적용
- SessionCleanupScheduler를 통해 10분 주기로 만료된 세션 자동 제거
- 서버에서 전달받은 sessionId를 기준으로 ChatSessionManager를 통해 세션 생성 및 메시지 저장
- 세션 유지 시간(sessionTimeoutMillis)을 30분으로 설정 
- Swagger 문서에 sessionId 처리 방식 명시
---

## 💖 리뷰 요청사항

- 세션 만료 처리 로직이 실제 사용 시 자연스럽게 동작하는지
- 향후 대화 이력 DB 저장 기능 추가 시 확장성 고려 여부