### PR TITLE
refactor: 게시글 좋아요 수, 댓글 수, 댓글 좋아요 수 카운팅 구현

### DIFF
--- a/src/main/java/org/scoula/community/comment/domain/CommentVO.java
+++ b/src/main/java/org/scoula/community/comment/domain/CommentVO.java
@@ -15,6 +15,7 @@ public class CommentVO {
     private Long postId;
     private Long memberId;
     private String content;
+    private int likeCount;
     private boolean isAnonymous;
     private Long parentComment;
     private LocalDateTime createdAt;

--- a/src/main/java/org/scoula/community/comment/dto/CommentCreateRequestDTO.java
+++ b/src/main/java/org/scoula/community/comment/dto/CommentCreateRequestDTO.java
@@ -18,9 +18,6 @@ import org.scoula.community.comment.domain.CommentVO;
 @ApiModel(description = "댓글 생성 요청 DTO")
 public class CommentCreateRequestDTO {
 
-    @ApiModelProperty(value = "댓글 ID", example = "1", required = false)
-    private Long commentId;
-
     @ApiModelProperty(value = "게시글 ID", example = "123", required = true)
     private Long postId;
 
@@ -33,33 +30,29 @@ public class CommentCreateRequestDTO {
     @ApiModelProperty(value = "익명 여부", example = "false", required = true)
     private boolean isAnonymous;
 
-    @ApiModelProperty(value = "부모 댓글 ID (답글일 경우)", example = "1")
+    @ApiModelProperty(value = "부모 댓글 ID (답글일 경우). " +
+            "null이면 최상위 댓글. " +
+            "부모 댓글이 존재한다면 해당 댓글이 존재하고 게시글이 일치하는지 검증 필요.", example = "1")
     private Long parentComment;
 
-    @ApiModelProperty(value = "댓글 생성 시간", example = "2025-07-23T10:00:00")
-    private LocalDateTime createdAt;
 
     public static CommentCreateRequestDTO of(CommentVO vo) {
         return vo == null ? null : CommentCreateRequestDTO.builder()
-                .commentId(vo.getCommentId())
                 .postId(vo.getPostId())
                 .memberId(vo.getMemberId())
                 .content(vo.getContent())
                 .isAnonymous(vo.isAnonymous())
                 .parentComment(vo.getParentComment())
-                .createdAt(vo.getCreatedAt())
                 .build();
     }
 
     public CommentVO toVo() {
         return CommentVO.builder()
-                .commentId(commentId)
                 .postId(postId)
                 .memberId(memberId)
                 .content(content)
                 .isAnonymous(isAnonymous)
                 .parentComment((parentComment != null && parentComment == 0) ? null : parentComment)
-                .createdAt(createdAt)
                 .build();
     }
 }

--- a/src/main/java/org/scoula/community/comment/dto/CommentResponseDTO.java
+++ b/src/main/java/org/scoula/community/comment/dto/CommentResponseDTO.java
@@ -1,6 +1,7 @@
 package org.scoula.community.comment.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.annotations.ApiModelProperty;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,6 +22,8 @@ public class CommentResponseDTO {
     private boolean isAnonymous;
     private Long parentComment;
     private LocalDateTime createdAt;
+    @ApiModelProperty(value = "좋아요 수", example = "15", position = 11)
+    private int likeCount;
 
     public static CommentResponseDTO of(CommentVO vo) {
         return vo == null ? null : CommentResponseDTO.builder()
@@ -31,6 +34,7 @@ public class CommentResponseDTO {
                 .isAnonymous(vo.isAnonymous())
                 .parentComment(vo.getParentComment())
                 .createdAt(vo.getCreatedAt())
+                .likeCount(vo.getLikeCount())
                 .build();
     }
 
@@ -43,6 +47,7 @@ public class CommentResponseDTO {
                 .isAnonymous(isAnonymous)
                 .parentComment(parentComment)
                 .createdAt(createdAt)
+                .likeCount(likeCount)
                 .build();
     }
 }

--- a/src/main/java/org/scoula/community/comment/exception/CommentExceptionHandler.java
+++ b/src/main/java/org/scoula/community/comment/exception/CommentExceptionHandler.java
@@ -28,5 +28,20 @@ public class CommentExceptionHandler {
 
         return new ResponseEntity<>(apiResponse, exception.getResponseCode().getHttpStatus());
     }
+    @ExceptionHandler(CommentParentMismatchException.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleCommentParentMismatchException(
+            CommentParentMismatchException exception,
+            HttpServletRequest request) {
 
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                exception.getMessage(),
+                exception.getResponseCode().name(),
+                request.getRequestURI()
+        );
+
+        ApiResponse<ErrorResponse> apiResponse = ApiResponse.fail(exception.getResponseCode(), errorResponse);
+
+        return new ResponseEntity<>(apiResponse, exception.getResponseCode().getHttpStatus());
+    }
 }

--- a/src/main/java/org/scoula/community/comment/exception/CommentParentMismatchException.java
+++ b/src/main/java/org/scoula/community/comment/exception/CommentParentMismatchException.java
@@ -1,0 +1,10 @@
+package org.scoula.community.comment.exception;
+
+import org.scoula.common.exception.BaseException;
+import org.scoula.response.ResponseCode;
+
+public class CommentParentMismatchException extends BaseException {
+    public CommentParentMismatchException(ResponseCode responseCode) {
+        super(responseCode);
+    }
+}

--- a/src/main/java/org/scoula/community/comment/mapper/CommentMapper.java
+++ b/src/main/java/org/scoula/community/comment/mapper/CommentMapper.java
@@ -9,6 +9,9 @@ public interface CommentMapper {
     public List<CommentVO> getList();
     public CommentVO get(Long no);
     public void create(CommentVO comment);
-    public int delete(Long no);
+    int deleteChild(Long commentId);
+    int deleteParentAndChildren(Long commentId);
     boolean existsById(Long commentId);
+    void updateLikeCount(Long commentId);
+    int countAllByParentOrSelf(Long commentId);
 }

--- a/src/main/java/org/scoula/community/comment/service/CommentServiceImpl.java
+++ b/src/main/java/org/scoula/community/comment/service/CommentServiceImpl.java
@@ -7,7 +7,9 @@ import org.scoula.community.comment.domain.CommentVO;
 import org.scoula.community.comment.dto.CommentCreateRequestDTO;
 import org.scoula.community.comment.dto.CommentResponseDTO;
 import org.scoula.community.comment.exception.CommentNotFoundException;
+import org.scoula.community.comment.exception.CommentParentMismatchException;
 import org.scoula.community.comment.mapper.CommentMapper;
+import org.scoula.community.post.mapper.PostMapper;
 import org.scoula.response.ResponseCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,14 +19,27 @@ import org.springframework.transaction.annotation.Transactional;
 @Log4j2
 public class CommentServiceImpl implements CommentService {
     private final CommentMapper commentMapper;
+    private final PostMapper postMapper;
+
     @Override
     @Transactional
     public CommentResponseDTO create(CommentCreateRequestDTO commentCreateRequestDTO) {
         log.info("create........." + commentCreateRequestDTO);
+        if (commentCreateRequestDTO.getParentComment() != null) {
+            CommentVO parent = commentMapper.get(commentCreateRequestDTO.getParentComment());
+            if (parent == null) {
+                throw new CommentParentMismatchException(ResponseCode.COMMENT_PARENT_MISMATCH);
+            }
+            if (!parent.getPostId().equals(commentCreateRequestDTO.getPostId())) {
+                throw new CommentParentMismatchException(ResponseCode.COMMENT_PARENT_MISMATCH);
+            }
+        }
+
 
         CommentVO vo = commentCreateRequestDTO.toVo();
         commentMapper.create(vo);
-        commentCreateRequestDTO.setCommentId(vo.getCommentId());
+        postMapper.incrementCommentCount(vo.getPostId());
+
         return get(vo.getCommentId());
     }
 
@@ -46,7 +61,6 @@ public class CommentServiceImpl implements CommentService {
                 .toList();
     }
 
-    @Override
     @Transactional
     public void delete(Long commentId) {
         log.info("delete........." + commentId);
@@ -54,6 +68,17 @@ public class CommentServiceImpl implements CommentService {
         if (comment == null) {
             throw new CommentNotFoundException(ResponseCode.COMMENT_NOT_FOUND);
         }
-        commentMapper.delete(commentId);
+
+        int deleteCount;
+        if (comment.getParentComment() == null) {
+            deleteCount = commentMapper.countAllByParentOrSelf(commentId);
+            commentMapper.deleteParentAndChildren(commentId);
+        } else {
+            // 자식 댓글: 본인만 삭제
+            deleteCount = 1;
+            commentMapper.deleteChild(commentId);
+        }
+
+        postMapper.decrementCommentCountBy(comment.getPostId(), deleteCount);
     }
 }

--- a/src/main/java/org/scoula/community/commentlike/service/CommentLikeServiceImpl.java
+++ b/src/main/java/org/scoula/community/commentlike/service/CommentLikeServiceImpl.java
@@ -5,6 +5,8 @@ import org.scoula.community.comment.exception.CommentNotFoundException;
 import org.scoula.community.comment.mapper.CommentMapper;
 import org.scoula.community.commentlike.domain.CommentLikeVO;
 import org.scoula.community.commentlike.mapper.CommentLikeMapper;
+import org.scoula.community.post.exception.PostNotFoundException;
+import org.scoula.community.postlike.domain.PostLikeVO;
 import org.scoula.response.ResponseCode;
 import org.springframework.stereotype.Service;
 
@@ -27,13 +29,16 @@ public class CommentLikeServiceImpl implements CommentLikeService {
                     .memberId(memberId)
                     .isLiked(true)
                     .build());
-            return true;
         } else {
             boolean newStatus = !existing.isLiked();
             existing.setLiked(newStatus);
             commentLikeMapper.update(existing);
-            return newStatus;
         }
+
+        commentMapper.updateLikeCount(commentId);
+
+        CommentLikeVO finalLike = commentLikeMapper.findByCommentIdAndMemberId(commentId, memberId);
+        return finalLike != null && finalLike.isLiked();
     }
 
     public int getLikeCount(Long commentId) {

--- a/src/main/java/org/scoula/community/post/controller/PostApiController.java
+++ b/src/main/java/org/scoula/community/post/controller/PostApiController.java
@@ -57,8 +57,7 @@ public class PostApiController {
     public ApiResponse<PostDetailsResponseDTO> update(
             @PathVariable Long postId,
             @RequestBody PostUpdateRequestDTO postUpdateRequestDTO) {
-        postUpdateRequestDTO.setPostId(postId);
-        PostDetailsResponseDTO updated = postService.update(postUpdateRequestDTO);
+        PostDetailsResponseDTO updated = postService.update(postId, postUpdateRequestDTO);
         return ApiResponse.success(ResponseCode.POST_UPDATE_SUCCESS, updated);
     }
 

--- a/src/main/java/org/scoula/community/post/domain/CategoryTag.java
+++ b/src/main/java/org/scoula/community/post/domain/CategoryTag.java
@@ -1,0 +1,33 @@
+package org.scoula.community.post.domain;
+
+import java.util.Arrays;
+
+public enum CategoryTag {
+    RECOMMEND("recommend", "추천"),
+    QUESTION("question", "질문"),
+    EXPERIENCE("experience", "경험"),
+    FREE("free", "자유");
+
+    private final String code;
+    private final String displayName;
+
+    CategoryTag(String code, String displayName) {
+        this.code = code;
+        this.displayName = displayName;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+    public static CategoryTag fromCode(String code) {
+        return Arrays.stream(values())
+                .filter(tag -> tag.code.equalsIgnoreCase(code))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid CategoryTag code: " + code));
+    }
+
+}

--- a/src/main/java/org/scoula/community/post/domain/PostVO.java
+++ b/src/main/java/org/scoula/community/post/domain/PostVO.java
@@ -1,13 +1,12 @@
 package org.scoula.community.post.domain;
 
 import java.time.LocalDateTime;
-import java.util.Date;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.scoula.community.board.domain.BoardVO;
+import org.scoula.community.comment.domain.CommentVO;
 
 @Data
 @NoArgsConstructor
@@ -17,8 +16,6 @@ public class PostVO {
     private Long postId;
     //연관관계 일대다
     private Long boardId;
-    //나중에 연관관계 설정 예정
-    private Long wmtiId;
     //나중에 연관관계 설정 예정
     private Long memberId;
     private String title;
@@ -32,5 +29,6 @@ public class PostVO {
     private PostStatus status;
 
     private List<PostAttachmentVO> attaches;
-
+    private CategoryTag categoryTag;
+    private ProductTag productTag;
 }

--- a/src/main/java/org/scoula/community/post/domain/ProductTag.java
+++ b/src/main/java/org/scoula/community/post/domain/ProductTag.java
@@ -1,0 +1,33 @@
+package org.scoula.community.post.domain;
+
+public enum ProductTag {
+    DEPOSIT("deposit", "예금"),
+    SAVINGS("savings", "적금"),
+    FUND("fund", "펀드"),
+    INSURANCE("insurance", "보험");
+
+    private final String code;
+    private final String displayName;
+
+    ProductTag(String code, String displayName) {
+        this.code = code;
+        this.displayName = displayName;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public static ProductTag fromCode(String code) {
+        for (ProductTag tag : values()) {
+            if (tag.code.equalsIgnoreCase(code)) {
+                return tag;
+            }
+        }
+        throw new IllegalArgumentException("Invalid ProductTag code: " + code);
+    }
+}

--- a/src/main/java/org/scoula/community/post/dto/PostCreateRequestDTO.java
+++ b/src/main/java/org/scoula/community/post/dto/PostCreateRequestDTO.java
@@ -9,9 +9,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.scoula.community.post.domain.CategoryTag;
 import org.scoula.community.post.domain.PostAttachmentVO;
 import org.scoula.community.post.domain.PostStatus;
 import org.scoula.community.post.domain.PostVO;
+import org.scoula.community.post.domain.ProductTag;
 import org.springframework.web.multipart.MultipartFile;
 
 @Data
@@ -22,14 +24,8 @@ import org.springframework.web.multipart.MultipartFile;
 @ApiModel(description = "게시글 생성 요청 DTO")
 public class PostCreateRequestDTO {
 
-    @ApiModelProperty(value = "게시글 고유 ID", example = "1", position = 1)
-    private Long postId;
-
     @ApiModelProperty(value = "게시판 ID (연관관계)", example = "1", required = true, position = 2)
     private Long boardId;
-
-    @ApiModelProperty(value = "WMTI ID (연관관계)", example = "10", position = 3)
-    private Long wmtiId;
 
     @ApiModelProperty(value = "작성자 회원 ID", example = "100", required = true, position = 4)
     private Long memberId;
@@ -40,23 +36,8 @@ public class PostCreateRequestDTO {
     @ApiModelProperty(value = "게시글 내용", example = "게시글 내용 예시", required = true, position = 6)
     private String content;
 
-    @ApiModelProperty(value = "게시글 생성 시간", example = "2025-07-23T02:29:35", position = 7)
-    private LocalDateTime createdAt;
-
-    @ApiModelProperty(value = "게시글 마지막 수정 시간", example = "2025-07-23T02:45:00", position = 8)
-    private LocalDateTime lastUpdated;
-
-    @ApiModelProperty(value = "핫게시판 등록 시간", example = "2025-07-23T03:00:00", position = 9)
-    private LocalDateTime hotBoardTime;
-
     @ApiModelProperty(value = "익명 여부", example = "true", position = 10)
     private boolean isAnonymous;
-
-    @ApiModelProperty(value = "좋아요 수", example = "15", position = 11)
-    private int likeCount;
-
-    @ApiModelProperty(value = "댓글 수", example = "5", position = 12)
-    private int commentCount;
 
     @ApiModelProperty(value = "게시글 상태 코드 (NORMAL, DELETED 등)", example = "NORMAL", position = 13)
     private String status;
@@ -67,42 +48,41 @@ public class PostCreateRequestDTO {
     @ApiModelProperty(value = "업로드할 파일 목록", dataType = "java.util.List", position = 15, notes = "MultipartFile 리스트")
     private List<MultipartFile> files;
 
+    @ApiModelProperty(value = "카테고리 태그 이름", example = "RECOMMEND", position = 17)
+    private String categoryTag;
+
+    @ApiModelProperty(value = "상품 태그 이름", example = "DEPOSIT", position = 17)
+    private String productTag;
+
     public static PostCreateRequestDTO of(PostVO vo) {
         return vo == null ? null : PostCreateRequestDTO.builder()
-                .postId(vo.getPostId())
                 .boardId(vo.getBoardId())
-                .wmtiId(vo.getWmtiId())
                 .memberId(vo.getMemberId())
                 .title(vo.getTitle())
                 .content(vo.getContent())
-                .createdAt(vo.getCreatedAt())
-                .lastUpdated(vo.getLastUpdated())
-                .hotBoardTime(vo.getHotBoardTime())
                 .isAnonymous(vo.isAnonymous())
-                .likeCount(vo.getLikeCount())
-                .commentCount(vo.getCommentCount())
                 .status(vo.getStatus() != null ? vo.getStatus().getCode() : PostStatus.NORMAL.getCode())
                 .attaches(vo.getAttaches())
+                .categoryTag(vo.getCategoryTag().getCode())
+                .productTag(vo.getProductTag().getCode())
                 .build();
     }
 
     public PostVO toVo() {
         PostStatus postStatusEnum = PostStatus.fromCode(status);
+        CategoryTag categoryTagEnum = CategoryTag.fromCode(categoryTag);
+        ProductTag productTagEnum = ProductTag.fromCode(productTag);
+
         return PostVO.builder()
-                .postId(postId)
                 .boardId(boardId)
-                .wmtiId(wmtiId)
                 .memberId(memberId)
                 .title(title)
                 .content(content)
-                .createdAt(createdAt)
-                .lastUpdated(lastUpdated)
-                .hotBoardTime(hotBoardTime)
                 .isAnonymous(isAnonymous)
-                .likeCount(likeCount)
-                .commentCount(commentCount)
                 .status(postStatusEnum)
                 .attaches(attaches)
+                .categoryTag(categoryTagEnum)
+                .productTag(productTagEnum)
                 .build();
     }
 }

--- a/src/main/java/org/scoula/community/post/dto/PostDetailsResponseDTO.java
+++ b/src/main/java/org/scoula/community/post/dto/PostDetailsResponseDTO.java
@@ -9,9 +9,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.scoula.community.comment.domain.CommentVO;
+import org.scoula.community.post.domain.CategoryTag;
 import org.scoula.community.post.domain.PostAttachmentVO;
 import org.scoula.community.post.domain.PostStatus;
 import org.scoula.community.post.domain.PostVO;
+import org.scoula.community.post.domain.ProductTag;
 import org.springframework.web.multipart.MultipartFile;
 
 @Data
@@ -67,11 +70,19 @@ public class PostDetailsResponseDTO {
     @ApiModelProperty(value = "업로드할 파일 목록", dataType = "java.util.List", position = 15, notes = "MultipartFile 리스트")
     private List<MultipartFile> files;
 
-    public static PostDetailsResponseDTO of(PostVO vo) {
+    @ApiModelProperty(value = "카테고리 태그 이름", example = "RECOMMEND", position = 17)
+    private String categoryTag;
+
+    @ApiModelProperty(value = "상품 태그 이름", example = "DEPOSIT", position = 17)
+    private String productTag;
+
+    @ApiModelProperty(value = "댓글 목록", position = 18)
+    private List<CommentVO> comments;
+
+    public static PostDetailsResponseDTO of(PostVO vo, List<CommentVO> comments) {
         return vo == null ? null : PostDetailsResponseDTO.builder()
                 .postId(vo.getPostId())
                 .boardId(vo.getBoardId())
-                .wmtiId(vo.getWmtiId())
                 .memberId(vo.getMemberId())
                 .title(vo.getTitle())
                 .content(vo.getContent())
@@ -83,15 +94,21 @@ public class PostDetailsResponseDTO {
                 .commentCount(vo.getCommentCount())
                 .status(vo.getStatus() != null ? vo.getStatus().getCode() : PostStatus.NORMAL.getCode())
                 .attaches(vo.getAttaches())
+                .categoryTag(vo.getCategoryTag().getCode())
+                .productTag(vo.getProductTag().getCode())
+                .commentCount(vo.getCommentCount())
+                .comments(comments)
                 .build();
     }
 
     public PostVO toVo() {
         PostStatus postStatusEnum = PostStatus.fromCode(status);
+        CategoryTag categoryTagEnum = CategoryTag.fromCode(categoryTag);
+        ProductTag productTagEnum = ProductTag.fromCode(productTag);
+
         return PostVO.builder()
                 .postId(postId)
                 .boardId(boardId)
-                .wmtiId(wmtiId)
                 .memberId(memberId)
                 .title(title)
                 .content(content)
@@ -103,6 +120,8 @@ public class PostDetailsResponseDTO {
                 .commentCount(commentCount)
                 .status(postStatusEnum)
                 .attaches(attaches)
+                .categoryTag(categoryTagEnum)
+                .productTag(productTagEnum)
                 .build();
     }
 }

--- a/src/main/java/org/scoula/community/post/dto/PostListResponseDTO.java
+++ b/src/main/java/org/scoula/community/post/dto/PostListResponseDTO.java
@@ -9,9 +9,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.scoula.community.post.domain.CategoryTag;
 import org.scoula.community.post.domain.PostAttachmentVO;
 import org.scoula.community.post.domain.PostStatus;
 import org.scoula.community.post.domain.PostVO;
+import org.scoula.community.post.domain.ProductTag;
 import org.springframework.web.multipart.MultipartFile;
 
 @Data
@@ -27,9 +29,6 @@ public class PostListResponseDTO {
 
     @ApiModelProperty(value = "게시판 ID (연관관계)", example = "1", required = true, position = 2)
     private Long boardId;
-
-    @ApiModelProperty(value = "WMTI ID (연관관계)", example = "10", position = 3)
-    private Long wmtiId;
 
     @ApiModelProperty(value = "작성자 회원 ID", example = "100", required = true, position = 4)
     private Long memberId;
@@ -67,11 +66,16 @@ public class PostListResponseDTO {
     @ApiModelProperty(value = "업로드할 파일 목록", dataType = "java.util.List", position = 15, notes = "MultipartFile 리스트")
     private List<MultipartFile> files;
 
+    @ApiModelProperty(value = "카테고리 태그 이름", example = "RECOMMEND", position = 17)
+    private String categoryTag;
+
+    @ApiModelProperty(value = "상품 태그 이름", example = "DEPOSIT", position = 17)
+    private String productTag;
+
     public static PostListResponseDTO of(PostVO vo) {
         return vo == null ? null : PostListResponseDTO.builder()
                 .postId(vo.getPostId())
                 .boardId(vo.getBoardId())
-                .wmtiId(vo.getWmtiId())
                 .memberId(vo.getMemberId())
                 .title(vo.getTitle())
                 .content(vo.getContent())
@@ -83,15 +87,19 @@ public class PostListResponseDTO {
                 .commentCount(vo.getCommentCount())
                 .status(vo.getStatus() != null ? vo.getStatus().getCode() : PostStatus.NORMAL.getCode())
                 .attaches(vo.getAttaches())
+                .categoryTag(vo.getCategoryTag().getCode())
+                .productTag(vo.getProductTag().getCode())
                 .build();
     }
 
     public PostVO toVo() {
         PostStatus postStatusEnum = PostStatus.fromCode(status);
+        CategoryTag categoryTagEnum = CategoryTag.fromCode(categoryTag);
+        ProductTag productTagEnum = ProductTag.fromCode(productTag);
+
         return PostVO.builder()
                 .postId(postId)
                 .boardId(boardId)
-                .wmtiId(wmtiId)
                 .memberId(memberId)
                 .title(title)
                 .content(content)
@@ -103,6 +111,8 @@ public class PostListResponseDTO {
                 .commentCount(commentCount)
                 .status(postStatusEnum)
                 .attaches(attaches)
+                .categoryTag(categoryTagEnum)
+                .productTag(productTagEnum)
                 .build();
     }
 }

--- a/src/main/java/org/scoula/community/post/dto/PostUpdateRequestDTO.java
+++ b/src/main/java/org/scoula/community/post/dto/PostUpdateRequestDTO.java
@@ -9,9 +9,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.scoula.community.post.domain.CategoryTag;
 import org.scoula.community.post.domain.PostAttachmentVO;
 import org.scoula.community.post.domain.PostStatus;
 import org.scoula.community.post.domain.PostVO;
+import org.scoula.community.post.domain.ProductTag;
 import org.springframework.web.multipart.MultipartFile;
 
 @Data
@@ -22,14 +24,8 @@ import org.springframework.web.multipart.MultipartFile;
 @ApiModel(description = "게시글 생성 요청 DTO")
 public class PostUpdateRequestDTO {
 
-    @ApiModelProperty(value = "게시글 고유 ID", example = "1", position = 1)
-    private Long postId;
-
     @ApiModelProperty(value = "게시판 ID (연관관계)", example = "1", required = true, position = 2)
     private Long boardId;
-
-    @ApiModelProperty(value = "WMTI ID (연관관계)", example = "10", position = 3)
-    private Long wmtiId;
 
     @ApiModelProperty(value = "작성자 회원 ID", example = "100", required = true, position = 4)
     private Long memberId;
@@ -40,23 +36,8 @@ public class PostUpdateRequestDTO {
     @ApiModelProperty(value = "게시글 내용", example = "게시글 내용 예시", required = true, position = 6)
     private String content;
 
-    @ApiModelProperty(value = "게시글 생성 시간", example = "2025-07-23T02:29:35", position = 7)
-    private LocalDateTime createdAt;
-
-    @ApiModelProperty(value = "게시글 마지막 수정 시간", example = "2025-07-23T02:45:00", position = 8)
-    private LocalDateTime lastUpdated;
-
-    @ApiModelProperty(value = "핫게시판 등록 시간", example = "2025-07-23T03:00:00", position = 9)
-    private LocalDateTime hotBoardTime;
-
     @ApiModelProperty(value = "익명 여부", example = "true", position = 10)
     private boolean isAnonymous;
-
-    @ApiModelProperty(value = "좋아요 수", example = "15", position = 11)
-    private int likeCount;
-
-    @ApiModelProperty(value = "댓글 수", example = "5", position = 12)
-    private int commentCount;
 
     @ApiModelProperty(value = "게시글 상태 코드 (NORMAL, DELETED 등)", example = "NORMAL", position = 13)
     private String status;
@@ -67,42 +48,41 @@ public class PostUpdateRequestDTO {
     @ApiModelProperty(value = "업로드할 파일 목록", dataType = "java.util.List", position = 15, notes = "MultipartFile 리스트")
     private List<MultipartFile> files;
 
+    @ApiModelProperty(value = "카테고리 태그 이름", example = "RECOMMEND", position = 17)
+    private String categoryTag;
+
+    @ApiModelProperty(value = "상품 태그 이름", example = "DEPOSIT", position = 17)
+    private String productTag;
+
     public static PostUpdateRequestDTO of(PostVO vo) {
         return vo == null ? null : PostUpdateRequestDTO.builder()
-                .postId(vo.getPostId())
                 .boardId(vo.getBoardId())
-                .wmtiId(vo.getWmtiId())
                 .memberId(vo.getMemberId())
                 .title(vo.getTitle())
                 .content(vo.getContent())
-                .createdAt(vo.getCreatedAt())
-                .lastUpdated(vo.getLastUpdated())
-                .hotBoardTime(vo.getHotBoardTime())
                 .isAnonymous(vo.isAnonymous())
-                .likeCount(vo.getLikeCount())
-                .commentCount(vo.getCommentCount())
                 .status(vo.getStatus() != null ? vo.getStatus().getCode() : PostStatus.NORMAL.getCode())
                 .attaches(vo.getAttaches())
+                .categoryTag(vo.getCategoryTag().getCode())
+                .productTag(vo.getProductTag().getCode())
                 .build();
     }
 
     public PostVO toVo() {
         PostStatus postStatusEnum = PostStatus.fromCode(status);
+        CategoryTag categoryTagEnum = CategoryTag.fromCode(categoryTag);
+        ProductTag productTagEnum = ProductTag.fromCode(productTag);
+
         return PostVO.builder()
-                .postId(postId)
                 .boardId(boardId)
-                .wmtiId(wmtiId)
                 .memberId(memberId)
                 .title(title)
                 .content(content)
-                .createdAt(createdAt)
-                .lastUpdated(lastUpdated)
-                .hotBoardTime(hotBoardTime)
                 .isAnonymous(isAnonymous)
-                .likeCount(likeCount)
-                .commentCount(commentCount)
                 .status(postStatusEnum)
                 .attaches(attaches)
+                .categoryTag(categoryTagEnum)
+                .productTag(productTagEnum)
                 .build();
     }
 }

--- a/src/main/java/org/scoula/community/post/handler/CategoryTagHandler.java
+++ b/src/main/java/org/scoula/community/post/handler/CategoryTagHandler.java
@@ -1,0 +1,33 @@
+package org.scoula.community.post.handler;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.scoula.community.post.domain.CategoryTag;
+import org.scoula.community.post.domain.PostStatus;
+
+public class CategoryTagHandler extends BaseTypeHandler<CategoryTag> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, CategoryTag tag, JdbcType jdbcType) throws SQLException {
+        ps.setString(i, tag.getCode());
+    }
+
+    @Override
+    public CategoryTag getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        return CategoryTag.fromCode(rs.getString(columnName));
+    }
+
+    @Override
+    public CategoryTag getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        return CategoryTag.fromCode(rs.getString(columnIndex));
+    }
+
+    @Override
+    public CategoryTag getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        return CategoryTag.fromCode(cs.getString(columnIndex));
+    }
+}

--- a/src/main/java/org/scoula/community/post/handler/ProductTagHandler.java
+++ b/src/main/java/org/scoula/community/post/handler/ProductTagHandler.java
@@ -1,0 +1,33 @@
+package org.scoula.community.post.handler;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.scoula.community.post.domain.CategoryTag;
+import org.scoula.community.post.domain.ProductTag;
+
+public class ProductTagHandler extends BaseTypeHandler<ProductTag> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, ProductTag tag, JdbcType jdbcType) throws SQLException {
+        ps.setString(i, tag.getCode());
+    }
+
+    @Override
+    public ProductTag getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        return ProductTag.fromCode(rs.getString(columnName));
+    }
+
+    @Override
+    public ProductTag getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        return ProductTag.fromCode(rs.getString(columnIndex));
+    }
+
+    @Override
+    public ProductTag getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        return ProductTag.fromCode(cs.getString(columnIndex));
+    }
+}

--- a/src/main/java/org/scoula/community/post/mapper/PostMapper.java
+++ b/src/main/java/org/scoula/community/post/mapper/PostMapper.java
@@ -2,6 +2,8 @@ package org.scoula.community.post.mapper;
 
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.scoula.community.comment.domain.CommentVO;
 import org.scoula.community.post.domain.PostAttachmentVO;
 import org.scoula.community.post.domain.PostVO;
 
@@ -19,4 +21,12 @@ public interface PostMapper {
     public List<PostAttachmentVO> getAttachmentList(Long bno);
     public PostAttachmentVO getAttachment(Long no);
     public int deleteAttachment(Long no);
+
+    List<CommentVO> getCommentsByPostId(Long no);
+    void updateLikeCount(Long postId);
+    int countCommentsByPostId(Long postId);
+
+    void incrementCommentCount(Long postId);
+    void decrementCommentCountBy(@Param("postId") Long postId, @Param("count") int count);
+
 }

--- a/src/main/java/org/scoula/community/post/service/PostService.java
+++ b/src/main/java/org/scoula/community/post/service/PostService.java
@@ -10,11 +10,11 @@ import org.scoula.community.post.dto.PostUpdateRequestDTO;
 
 public interface PostService {
     public List<PostListResponseDTO> getList();
-    public PostDetailsResponseDTO get(Long no);
+    public PostDetailsResponseDTO get(Long postId);
     public PostDetailsResponseDTO create(PostCreateRequestDTO postCreateRequestDTO);
-    public PostDetailsResponseDTO update(PostUpdateRequestDTO postCreateRequestDTO);
+    public PostDetailsResponseDTO update(Long postId, PostUpdateRequestDTO postCreateRequestDTO);
     public void delete(Long no);
-    public PostAttachmentVO getAttachment(Long no);
-    public boolean deleteAttachment(Long no);
+    public PostAttachmentVO getAttachment(Long postId);
+    public boolean deleteAttachment(Long postId);
 
 }

--- a/src/main/java/org/scoula/community/post/service/PostServiceImpl.java
+++ b/src/main/java/org/scoula/community/post/service/PostServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.scoula.common.util.UploadFiles;
+import org.scoula.community.comment.domain.CommentVO;
 import org.scoula.community.post.domain.PostAttachmentVO;
 import org.scoula.community.post.domain.PostVO;
 import org.scoula.community.post.dto.PostCreateRequestDTO;
@@ -42,7 +43,12 @@ public class PostServiceImpl implements PostService {
         if (post == null) {
             throw new PostNotFoundException(ResponseCode.POST_NOT_FOUND);
         }
-        return PostDetailsResponseDTO.of(post);
+
+        List<CommentVO> comments = postMapper.getCommentsByPostId(no);
+        int commentCount = postMapper.countCommentsByPostId(no);
+        post.setCommentCount(commentCount);
+
+        return PostDetailsResponseDTO.of(post, comments);
     }
 
     @Override
@@ -52,7 +58,6 @@ public class PostServiceImpl implements PostService {
 
         PostVO vo = postCreateRequestDTO.toVo();
         postMapper.create(vo);
-        postCreateRequestDTO.setPostId(vo.getPostId());
         List<MultipartFile> files = postCreateRequestDTO.getFiles();
         if (files != null && !files.isEmpty()) {
             upload(vo.getPostId(), files);
@@ -61,15 +66,15 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public PostDetailsResponseDTO update(PostUpdateRequestDTO postCreateRequestDTO) {
-        log.info("update........." + postCreateRequestDTO);
+    public PostDetailsResponseDTO update(Long postId, PostUpdateRequestDTO postUpdateRequestDTO) {
+        log.info("update........." + postUpdateRequestDTO);
 
-        if (postMapper.get(postCreateRequestDTO.getPostId()) == null) {
+        if (postMapper.get(postId) == null) {
             throw new PostNotFoundException(ResponseCode.POST_NOT_FOUND);
         }
 
-        postMapper.update(postCreateRequestDTO.toVo());
-        return get(postCreateRequestDTO.getPostId());
+        postMapper.update(postUpdateRequestDTO.toVo());
+        return get(postId);
     }
 
 

--- a/src/main/java/org/scoula/community/postlike/service/PostLikeServiceImpl.java
+++ b/src/main/java/org/scoula/community/postlike/service/PostLikeServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 public class PostLikeServiceImpl implements PostLikeService {
     private final PostLikeMapper postLikeMapper;
     private final PostMapper postMapper;
+
     public boolean toggleLike(Long postId, Long memberId) {
         if (!postMapper.existsById(postId)) {
             throw new PostNotFoundException(ResponseCode.POST_NOT_FOUND);
@@ -27,14 +28,18 @@ public class PostLikeServiceImpl implements PostLikeService {
                     .memberId(memberId)
                     .isLiked(true)
                     .build());
-            return true;
         } else {
             boolean newStatus = !existing.isLiked();
             existing.setLiked(newStatus);
             postLikeMapper.update(existing);
-            return newStatus;
         }
+
+        postMapper.updateLikeCount(postId);
+
+        PostLikeVO finalLike = postLikeMapper.findByPostIdAndMemberId(postId, memberId);
+        return finalLike != null && finalLike.isLiked();
     }
+
 
     public int getLikeCount(Long postId) {
         if (!postMapper.existsById(postId)) {
@@ -47,7 +52,7 @@ public class PostLikeServiceImpl implements PostLikeService {
     @Override
     public boolean isLikedByMember(Long postId, Long memberId) {
         if (!postMapper.existsById(postId)) {
-            throw new CommentNotFoundException(ResponseCode.POST_NOT_FOUND);
+            throw new PostNotFoundException(ResponseCode.POST_NOT_FOUND);
         }
         PostLikeVO like = postLikeMapper.findByPostIdAndMemberId(postId, memberId);
         return like != null && like.isLiked();

--- a/src/main/java/org/scoula/response/ResponseCode.java
+++ b/src/main/java/org/scoula/response/ResponseCode.java
@@ -69,6 +69,7 @@ public enum ResponseCode {
     COMMENT_DETAILS_SUCCESS(HttpStatus.OK, "댓글 상세 정보 조회가 성공되었습니다"),
     COMMENT_DELETE_SUCCESS(HttpStatus.OK, "댓글 삭제가 성공되었습니다"),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다"),
+    COMMENT_PARENT_MISMATCH(HttpStatus.BAD_REQUEST, "부모 댓글이 존재하지 않거나 게시글이 일치하지 않습니다."),
 
     /**
      * Community - PostLike

--- a/src/main/resources/org/scoula/community/comment/mapper/CommentMapper.xml
+++ b/src/main/resources/org/scoula/community/comment/mapper/CommentMapper.xml
@@ -27,38 +27,78 @@
     <!-- 댓글 단일 조회 -->
     <select id="get" parameterType="long" resultType="org.scoula.community.comment.domain.CommentVO">
         SELECT
-            comment_id,
-            post_id,
-            member_id,
-            content,
-            is_anonymous,
-            parent_comment,
-            created_at
-        FROM finmate.comment
-        WHERE comment_id = #{commentId}
+            c.comment_id,
+            c.post_id,
+            c.member_id,
+            c.content,
+            c.is_anonymous,
+            c.parent_comment,
+            c.created_at,
+            (
+                SELECT COUNT(*)
+                FROM finmate.comment_like cl
+                WHERE cl.comment_id = c.comment_id AND cl.is_liked = true
+            ) AS like_count
+        FROM finmate.comment c
+        WHERE c.comment_id = #{commentId}
     </select>
+
 
     <!-- 댓글 전체 조회 -->
     <select id="getList" resultType="org.scoula.community.comment.domain.CommentVO">
         SELECT
-            comment_id,
-            post_id,
-            member_id,
-            content,
-            is_anonymous,
-            parent_comment,
-            created_at
-        FROM finmate.comment
-        ORDER BY created_at ASC
+            c.comment_id,
+            c.post_id,
+            c.member_id,
+            c.content,
+            c.is_anonymous,
+            c.parent_comment,
+            c.created_at,
+            (
+                SELECT COUNT(*)
+                FROM finmate.comment_like cl
+                WHERE cl.comment_id = c.comment_id AND cl.is_liked = true
+            ) AS like_count
+        FROM finmate.comment c
+        ORDER BY c.created_at ASC
+    </select>
+    <!-- 댓글 삭제 (부모 댓글 및 자식 댓글 모두 물리 삭제) -->
+    <!-- 부모댓글인지 체크 (대댓글이 있는지 확인) -->
+    <select id="hasChildren" parameterType="long" resultType="boolean">
+        SELECT EXISTS (
+            SELECT 1 FROM finmate.comment WHERE parent_comment = #{commentId}
+        )
     </select>
 
-    <!-- 댓글 삭제 (부모 댓글 및 자식 댓글 모두 물리 삭제) -->
-    <delete id="delete" parameterType="long">
+
+    <!-- 부모 댓글 + 자식 댓글 모두 삭제 -->
+    <delete id="deleteParentAndChildren" parameterType="long">
+        DELETE FROM finmate.comment
+        WHERE comment_id = #{commentId} OR parent_comment = #{commentId}
+    </delete>
+
+    <!-- 자식 댓글만 삭제 -->
+    <delete id="deleteChild" parameterType="long">
         DELETE FROM finmate.comment
         WHERE comment_id = #{commentId}
-           OR parent_comment = #{commentId}
     </delete>
+
     <select id="existsById" resultType="boolean">
         SELECT COUNT(*) > 0 FROM finmate.comment WHERE comment_id = #{commentId}
+    </select>
+    <update id="updateLikeCount">
+        UPDATE comment
+        SET like_count = (
+            SELECT COUNT(*)
+            FROM comment_like
+            WHERE comment.comment_id = #{commentId}
+              AND is_liked = true
+        )
+        WHERE comment_id = #{commentId}
+    </update>
+    <select id="countAllByParentOrSelf" resultType="int">
+        SELECT COUNT(*) FROM comment
+        WHERE comment_id = #{commentId}
+           OR parent_comment = #{commentId}
     </select>
 </mapper>

--- a/src/main/resources/org/scoula/community/post/mapper/PostMapper.xml
+++ b/src/main/resources/org/scoula/community/post/mapper/PostMapper.xml
@@ -8,11 +8,11 @@
     <!-- 게시글 등록 -->
     <insert id="create" parameterType="org.scoula.community.post.domain.PostVO" useGeneratedKeys="true" keyProperty="postId">
         INSERT INTO finmate.post (
-            board_id, wmti_id, member_id, title, content, created_at, last_updated, hot_board_time,
-            is_anonymous, like_count, comment_count, status
+            board_id, member_id, title, content, created_at, last_updated,
+            is_anonymous, status, category_tag, product_tag
         ) VALUES (
-                     #{boardId}, #{wmtiId}, #{memberId}, #{title}, #{content}, NOW(), NOW(), #{hotBoardTime},
-                     #{anonymous}, #{likeCount}, #{commentCount}, #{status.code}
+                     #{boardId}, #{memberId}, #{title}, #{content}, NOW(), NOW(),
+                     #{anonymous}, #{status.code}, #{categoryTag}, #{productTag}
                  )
     </insert>
 
@@ -33,10 +33,9 @@
             content = #{content},
             last_updated = NOW(),
             is_anonymous = #{anonymous},
-            hot_board_time = #{hotBoardTime},
-            like_count = #{likeCount},
-            comment_count = #{commentCount},
-            status = #{status.code}
+            status = #{status.code},
+            category_tag = #{categoryTag.code},
+            product_tag = #{productTag.code}
         WHERE post_id = #{postId}
     </update>
 
@@ -53,9 +52,9 @@
     <!-- 게시글 목록 조회 -->
     <select id="getList" resultType="org.scoula.community.post.domain.PostVO">
         SELECT
-            post_id, board_id, wmti_id, member_id, title, content,
+            post_id, board_id, member_id, title, content,
             created_at, last_updated, hot_board_time,
-            is_anonymous, like_count, comment_count, status
+            is_anonymous, like_count, comment_count, status, category_tag, product_tag
         FROM finmate.post
         ORDER BY created_at DESC
     </select>
@@ -63,9 +62,9 @@
     <!-- 게시글 단건 조회 -->
     <select id="get" parameterType="long" resultType="org.scoula.community.post.domain.PostVO">
         SELECT
-            post_id, board_id, wmti_id, member_id, title, content,
+            post_id, board_id, member_id, title, content,
             created_at, last_updated, hot_board_time,
-            is_anonymous, like_count, comment_count, status
+            is_anonymous, like_count, comment_count, status, category_tag, product_tag
         FROM finmate.post
         WHERE post_id = #{postId}
     </select>
@@ -90,4 +89,35 @@
     <select id="existsById" resultType="boolean">
         SELECT COUNT(*) > 0 FROM finmate.post WHERE post_id = #{postId}
     </select>
+
+    <select id="getCommentsByPostId" parameterType="long" resultType="org.scoula.community.comment.domain.CommentVO">
+        SELECT comment_id, post_id, member_id, content, is_anonymous, parent_comment, created_at
+        FROM finmate.comment
+        WHERE post_id = #{postId}
+        ORDER BY created_at ASC
+    </select>
+    <select id="countCommentsByPostId" parameterType="long" resultType="int">
+        SELECT COUNT(*) FROM comment WHERE post_id = #{postId}
+    </select>
+    <update id="updateLikeCount">
+        UPDATE post
+        SET like_count = (
+            SELECT COUNT(*) FROM post_like
+            WHERE post_id = #{postId} AND is_liked = true
+        )
+        WHERE post_id = #{postId}
+    </update>
+
+    <update id="incrementCommentCount">
+        UPDATE post
+        SET comment_count = comment_count + 1
+        WHERE post_id = #{postId}
+    </update>
+
+    <update id="decrementCommentCountBy">
+        UPDATE post
+        SET comment_count = GREATEST(comment_count - #{count}, 0)
+        WHERE post_id = #{postId}
+    </update>
+
 </mapper>

--- a/src/main/resources/org/scoula/community/postlike/mapper/PostLikeMapper.xml
+++ b/src/main/resources/org/scoula/community/postlike/mapper/PostLikeMapper.xml
@@ -25,5 +25,4 @@
         SELECT COUNT(*) FROM post_like
         WHERE post_id = #{postId} AND is_liked = true
     </select>
-
 </mapper>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> PR과 연관된 이슈 번호를 작성해주세요.

- close: #35

## 🪄 작업 내용
> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.  
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- 게시글 카테고리 태그 및 상품 태그 enum 구현  
- 게시글 좋아요 수 카운팅 기능 추가  
- 댓글 수 및 댓글 좋아요 수 카운팅 기능 구현  
- 댓글과 대댓글(답글) 처리를 명확히 분리하여 부모 댓글 삭제 시 자식 댓글도 함께 삭제되도록 구현  
- 대댓글 작성 시 부모 댓글이 같은 게시글에 속하는지 검증 로직 추가하여 데이터 무결성 확보  
- 댓글 삭제 시 게시글의 댓글 수를 정확히 반영하도록 삭제 개수 기반으로 카운트 조정  

## 💖 리뷰 요청사항
> 특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

- 태그 enum 설계 및 매핑 부분에 대한 피드백 부탁드립니다.  
- 좋아요/댓글 수 카운팅 로직이 DB와 잘 연동되는지 확인해주시면 감사하겠습니다.  
- 댓글과 대댓글 삭제 및 생성 시 무결성 검증 및 카운트 반영이 잘 처리되고 있는지 중점적으로 봐주시면 좋겠습니다.  
- 코드 전반적인 가독성 및 성능 부분도 봐주시면 좋겠습니다.
