### PR TITLE
refactor: 스크랩 수 반환

### DIFF
--- a/src/main/java/org/scoula/community/comment/controller/CommentApiController.java
+++ b/src/main/java/org/scoula/community/comment/controller/CommentApiController.java
@@ -8,7 +8,6 @@ import lombok.extern.log4j.Log4j2;
 import org.scoula.community.comment.dto.CommentCreateRequestDTO;
 import org.scoula.community.comment.dto.CommentResponseDTO;
 import org.scoula.community.comment.service.CommentService;
-import org.scoula.community.post.dto.PostListResponseDTO;
 import org.scoula.response.ApiResponse;
 import org.scoula.response.ResponseCode;
 import org.springframework.web.bind.annotation.DeleteMapping;

--- a/src/main/java/org/scoula/community/comment/service/CommentServiceImpl.java
+++ b/src/main/java/org/scoula/community/comment/service/CommentServiceImpl.java
@@ -12,7 +12,6 @@ import org.scoula.community.comment.exception.CommentParentMismatchException;
 import org.scoula.community.comment.mapper.CommentMapper;
 import org.scoula.community.commentlike.mapper.CommentLikeMapper;
 import org.scoula.community.commentlike.service.CommentLikeService;
-import org.scoula.community.post.dto.PostListResponseDTO;
 import org.scoula.community.post.exception.PostNotFoundException;
 import org.scoula.community.post.mapper.PostMapper;
 import org.scoula.member.mapper.MemberMapper;

--- a/src/main/java/org/scoula/community/post/domain/PostVO.java
+++ b/src/main/java/org/scoula/community/post/domain/PostVO.java
@@ -21,10 +21,11 @@ public class PostVO {
     private LocalDateTime createdAt;
     private LocalDateTime lastUpdated;
     private boolean isAnonymous;
-    private int likeCount;
     private boolean isLiked;
     private boolean isScraped;
-    private int commentCount;
+    private int likeCount = 0;       // 기본 0
+    private int commentCount = 0;    // 기본 0
+    private int scrapCount = 0;      // 기본 0
     private PostStatus status;
     private ProductTag productTag;
     private List<PostAttachmentVO> attachments;

--- a/src/main/java/org/scoula/community/post/dto/PostDetailsResponseDTO.java
+++ b/src/main/java/org/scoula/community/post/dto/PostDetailsResponseDTO.java
@@ -66,6 +66,8 @@ public class PostDetailsResponseDTO {
 
     private boolean isLiked;
     private boolean isScraped;
+    private int scrapCount;
+
 //    @ApiModelProperty(value = "첨부파일 목록", position = 14)
 //    private List<PostAttachmentVO> attaches;
 //
@@ -92,6 +94,7 @@ public class PostDetailsResponseDTO {
 //                .attaches(vo.getAttachments())
                 .isLiked(vo.isLiked())
                 .isScraped(vo.isScraped())
+                .scrapCount(vo.getScrapCount())
                 .build();
     }
 
@@ -115,6 +118,7 @@ public class PostDetailsResponseDTO {
                 .isLiked(isLiked)
                 .isScraped(isScraped)
 //                .attachments(attaches)
+                .scrapCount(scrapCount)
                 .build();
     }
 }

--- a/src/main/java/org/scoula/community/post/dto/PostListResponseDTO.java
+++ b/src/main/java/org/scoula/community/post/dto/PostListResponseDTO.java
@@ -52,6 +52,7 @@ public class PostListResponseDTO {
 
     private boolean isLiked;
     private boolean isScraped;
+    private int scrapCount;
 
     @ApiModelProperty(value = "게시글 상태 코드 (NORMAL, DELETED 등)", example = "NORMAL", position = 13)
     private String status;
@@ -79,6 +80,7 @@ public class PostListResponseDTO {
 //                .attachmentCount(vo.getAttachments() != null ? vo.getAttachments().size() : 0)
                 .isLiked(vo.isLiked())
                 .isScraped(vo.isScraped())
+                .scrapCount(vo.getScrapCount())
                 .build();
     }
 
@@ -101,6 +103,7 @@ public class PostListResponseDTO {
                 .productTag(productTagEnum)
                 .isLiked(isLiked)
                 .isScraped(isScraped)
+                .scrapCount(scrapCount)
                 .build();
     }
 }

--- a/src/main/java/org/scoula/community/post/service/HotPostSchedulerService.java
+++ b/src/main/java/org/scoula/community/post/service/HotPostSchedulerService.java
@@ -75,16 +75,22 @@ public class HotPostSchedulerService {
 
             List<PostListResponseDTO> hotPostDTOs = hotPosts.stream()
                     .map(post -> {
+                        int likeCount = postLikeMapper.countByPostId(post.getPostId());
+                        int commentCount = postMapper.countCommentsByPostId(post.getPostId());
+                        int scrapCount = scrapMapper.countScrapsByPostId(post.getPostId());
+
+                        post.setLikeCount(likeCount);
+                        post.setCommentCount(commentCount);
+                        post.setScrapCount(scrapCount); // scrapCount 필드 및 메서드 필요
+
                         boolean isLiked = false;
                         boolean isScraped = false;
-
                         if (currentUserId != null) {
                             isLiked = postLikeMapper.existsByPostIdAndMemberId(post.getPostId(), currentUserId);
                             isScraped = scrapMapper.existsScrap(post.getPostId(), currentUserId);
                         }
                         post.setLiked(isLiked);
                         post.setScraped(isScraped);
-
                         return PostListResponseDTO.of(post);
                     })
                     .limit(5)
@@ -128,9 +134,16 @@ public class HotPostSchedulerService {
 
         List<PostListResponseDTO> hotPostDTOs = hotPosts.stream()
                 .map(post -> {
+                    int likeCount = postLikeMapper.countByPostId(post.getPostId());
+                    int commentCount = postMapper.countCommentsByPostId(post.getPostId());
+                    int scrapCount = scrapMapper.countScrapsByPostId(post.getPostId());
+
+                    post.setLikeCount(likeCount);
+                    post.setCommentCount(commentCount);
+                    post.setScrapCount(scrapCount); // scrapCount 필드 및 메서드 필요
+
                     boolean isLiked = false;
                     boolean isScraped = false;
-
                     if (currentUserId != null) {
                         isLiked = postLikeMapper.existsByPostIdAndMemberId(post.getPostId(), currentUserId);
                         isScraped = scrapMapper.existsScrap(post.getPostId(), currentUserId);

--- a/src/main/java/org/scoula/community/post/service/PostServiceImpl.java
+++ b/src/main/java/org/scoula/community/post/service/PostServiceImpl.java
@@ -50,13 +50,21 @@ public class PostServiceImpl implements PostService {
 
         return postMapper.getList().stream()
                 .map(post -> {
+                    int likeCount = postLikeMapper.countByPostId(post.getPostId());
+                    int commentCount = postMapper.countCommentsByPostId(post.getPostId());
+                    int scrapCount = scrapMapper.countScrapsByPostId(post.getPostId()); // scrapCount 메서드 필요
+
+                    post.setLikeCount(likeCount);
+                    post.setCommentCount(commentCount);
+                    post.setScrapCount(scrapCount);
+
                     boolean isLiked = false;
                     boolean isScraped = false;
-
                     if (currentUserId != null) {
                         isLiked = postLikeMapper.existsByPostIdAndMemberId(post.getPostId(), currentUserId);
                         isScraped = scrapMapper.existsScrap(post.getPostId(), currentUserId);
                     }
+
                     post.setLiked(isLiked);
                     post.setScraped(isScraped);
                     return PostListResponseDTO.of(post);
@@ -75,19 +83,20 @@ public class PostServiceImpl implements PostService {
 //        post.setAttachments(attachments);
 
         List<CommentVO> comments = postMapper.getCommentsByPostId(postId);
-        int commentCount = postMapper.countCommentsByPostId(postId);
-        post.setCommentCount(commentCount);
-        int likeCount = postLikeMapper.countByPostId(postId);
-        log.info("likeCount: {}", likeCount);
-        post.setLikeCount(likeCount);
-
         Long currentUserId = getCurrentUserIdAsLong();
+        int likeCount = postLikeMapper.countByPostId(post.getPostId());
+        int commentCount = postMapper.countCommentsByPostId(post.getPostId());
+        int scrapCount = scrapMapper.countScrapsByPostId(post.getPostId());
+
+        post.setLikeCount(likeCount);
+        post.setCommentCount(commentCount);
+        post.setScrapCount(scrapCount);
+
         boolean isLiked = false;
         boolean isScraped = false;
-
         if (currentUserId != null) {
-            isLiked = postLikeService.isLikedByMember(postId);
-            isScraped = scrapService.isScraped(postId);
+            isLiked = postLikeMapper.existsByPostIdAndMemberId(post.getPostId(), currentUserId);
+            isScraped = scrapMapper.existsScrap(post.getPostId(), currentUserId);
         }
         post.setLiked(isLiked);
         post.setScraped(isScraped);
@@ -207,15 +216,18 @@ public class PostServiceImpl implements PostService {
         for (PostVO post : posts) {
             Long postId = post.getPostId();
 
-            int commentCount = postMapper.countCommentsByPostId(postId);
-            post.setCommentCount(commentCount);
+            Long currentUserId = getCurrentUserIdAsLong();
+            int likeCount = postLikeMapper.countByPostId(post.getPostId());
+            int commentCount = postMapper.countCommentsByPostId(post.getPostId());
+            int scrapCount = scrapMapper.countScrapsByPostId(post.getPostId());
 
-            int likeCount = postLikeMapper.countByPostId(postId);
             post.setLikeCount(likeCount);
-            
-            if(memberId != null) {
-                isLiked = postLikeMapper.existsByPostIdAndMemberId(postId, memberId);
-                isScraped = scrapMapper.existsScrap(postId, memberId);
+            post.setCommentCount(commentCount);
+            post.setScrapCount(scrapCount);
+
+            if (currentUserId != null) {
+                isLiked = postLikeMapper.existsByPostIdAndMemberId(post.getPostId(), currentUserId);
+                isScraped = scrapMapper.existsScrap(post.getPostId(), currentUserId);
             }
             post.setLiked(isLiked);
             post.setScraped(isScraped);
@@ -236,16 +248,18 @@ public class PostServiceImpl implements PostService {
         List<PostVO> posts = postMapper.getPostsByMemberId(memberId);
         for (PostVO post : posts) {
             Long postId = post.getPostId();
-            int commentCount = postMapper.countCommentsByPostId(post.getPostId());
-            post.setCommentCount(commentCount);
-
+            Long currentUserId = getCurrentUserIdAsLong();
             int likeCount = postLikeMapper.countByPostId(post.getPostId());
-            post.setLikeCount(likeCount);
-            
+            int commentCount = postMapper.countCommentsByPostId(post.getPostId());
+            int scrapCount = scrapMapper.countScrapsByPostId(post.getPostId());
 
-            if(memberId != null) {
-                isLiked = postLikeMapper.existsByPostIdAndMemberId(postId, memberId);
-                isScraped = scrapMapper.existsScrap(postId, memberId);
+            post.setLikeCount(likeCount);
+            post.setCommentCount(commentCount);
+            post.setScrapCount(scrapCount);
+
+            if (currentUserId != null) {
+                isLiked = postLikeMapper.existsByPostIdAndMemberId(post.getPostId(), currentUserId);
+                isScraped = scrapMapper.existsScrap(post.getPostId(), currentUserId);
             }
             post.setLiked(isLiked);
             post.setScraped(isScraped);
@@ -284,14 +298,18 @@ public class PostServiceImpl implements PostService {
         List<PostVO> posts = postMapper.getHotPostsByBoard(boardId);
         for (PostVO post : posts) {
             Long postId = post.getPostId();
-            int commentCount = postMapper.countCommentsByPostId(post.getPostId());
-            post.setCommentCount(commentCount);
-
+            Long currentUserId = getCurrentUserIdAsLong();
             int likeCount = postLikeMapper.countByPostId(post.getPostId());
+            int commentCount = postMapper.countCommentsByPostId(post.getPostId());
+            int scrapCount = scrapMapper.countScrapsByPostId(post.getPostId());
+
             post.setLikeCount(likeCount);
-            if(memberId != null) {
-                isLiked = postLikeMapper.existsByPostIdAndMemberId(postId, memberId);
-                isScraped = scrapMapper.existsScrap(postId, memberId);
+            post.setCommentCount(commentCount);
+            post.setScrapCount(scrapCount);
+
+            if (currentUserId != null) {
+                isLiked = postLikeMapper.existsByPostIdAndMemberId(post.getPostId(), currentUserId);
+                isScraped = scrapMapper.existsScrap(post.getPostId(), currentUserId);
             }
             post.setLiked(isLiked);
             post.setScraped(isScraped);
@@ -337,15 +355,18 @@ public class PostServiceImpl implements PostService {
         List<PostVO> posts = postMapper.getAllHotPosts();
         for (PostVO post : posts) {
             Long postId = post.getPostId();
-            int commentCount = postMapper.countCommentsByPostId(post.getPostId());
-            post.setCommentCount(commentCount);
-
+            Long currentUserId = getCurrentUserIdAsLong();
             int likeCount = postLikeMapper.countByPostId(post.getPostId());
-            post.setLikeCount(likeCount);
+            int commentCount = postMapper.countCommentsByPostId(post.getPostId());
+            int scrapCount = scrapMapper.countScrapsByPostId(post.getPostId());
 
-            if(memberId != null) {
-                isLiked = postLikeMapper.existsByPostIdAndMemberId(postId, memberId);
-                isScraped = scrapMapper.existsScrap(postId, memberId);
+            post.setLikeCount(likeCount);
+            post.setCommentCount(commentCount);
+            post.setScrapCount(scrapCount);
+
+            if (currentUserId != null) {
+                isLiked = postLikeMapper.existsByPostIdAndMemberId(post.getPostId(), currentUserId);
+                isScraped = scrapMapper.existsScrap(post.getPostId(), currentUserId);
             }
             post.setLiked(isLiked);
             post.setScraped(isScraped);

--- a/src/main/java/org/scoula/community/postlike/service/PostLikeServiceImpl.java
+++ b/src/main/java/org/scoula/community/postlike/service/PostLikeServiceImpl.java
@@ -60,8 +60,21 @@ public class PostLikeServiceImpl implements PostLikeService {
 
         return postLikeMapper.getLikedPostsByMemberId(memberId).stream()
                 .map(post -> {
-                    boolean isLiked = true; 
-                    boolean isScraped = scrapMapper.existsScrap(post.getPostId(), memberId);
+                    Long currentUserId = getCurrentUserIdAsLong();
+                    int likeCount = postLikeMapper.countByPostId(post.getPostId());
+                    int commentCount = postMapper.countCommentsByPostId(post.getPostId());
+                    int scrapCount = scrapMapper.countScrapsByPostId(post.getPostId());
+
+                    post.setLikeCount(likeCount);
+                    post.setCommentCount(commentCount);
+                    post.setScrapCount(scrapCount); // scrapCount 필드 및 메서드 필요
+
+                    boolean isLiked = false;
+                    boolean isScraped = false;
+                    if (currentUserId != null) {
+                        isLiked = postLikeMapper.existsByPostIdAndMemberId(post.getPostId(), currentUserId);
+                        isScraped = scrapMapper.existsScrap(post.getPostId(), currentUserId);
+                    }
                     post.setLiked(isLiked);
                     post.setScraped(isScraped);
                     return PostListResponseDTO.of(post);

--- a/src/main/java/org/scoula/community/scrap/service/ScrapServiceImpl.java
+++ b/src/main/java/org/scoula/community/scrap/service/ScrapServiceImpl.java
@@ -69,13 +69,21 @@ public class ScrapServiceImpl implements ScrapService {
 
         return scrapMapper.getScrapPostsByMemberId(memberId).stream()
                 .map(post -> {
-                    boolean isLiked = postLikeMapper.existsByPostIdAndMemberId(post.getPostId(), memberId);
-                    boolean isScraped = true;
-
-                    int commentCount = postMapper.countCommentsByPostId(post.getPostId());
-                    post.setCommentCount(commentCount);
+                    Long currentUserId = getCurrentUserIdAsLong();
                     int likeCount = postLikeMapper.countByPostId(post.getPostId());
+                    int commentCount = postMapper.countCommentsByPostId(post.getPostId());
+                    int scrapCount = scrapMapper.countScrapsByPostId(post.getPostId());
+
                     post.setLikeCount(likeCount);
+                    post.setCommentCount(commentCount);
+                    post.setScrapCount(scrapCount); // scrapCount 필드 및 메서드 필요
+
+                    boolean isLiked = false;
+                    boolean isScraped = false;
+                    if (currentUserId != null) {
+                        isLiked = postLikeMapper.existsByPostIdAndMemberId(post.getPostId(), currentUserId);
+                        isScraped = scrapMapper.existsScrap(post.getPostId(), currentUserId);
+                    }
                     post.setLiked(isLiked);
                     post.setScraped(isScraped);
                     return PostListResponseDTO.of(post);


### PR DESCRIPTION
## #️⃣연관된 이슈
> PR과 연관된 이슈 번호를 작성해주세요. 

- close: #51 

## 🪄작업 내용
> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- 게시글 상세 조회 및 리스트 조회 응답에 `scrapCount`(스크랩 수) 반환 추가
- `PostVO`에 `scrapCount` 필드 추가
- `ScrapMapper`에 게시글별 스크랩 수 조회 메서드 추가 (`countByPostId`)
- 게시글 조회 시 `scrapCount` 세팅하도록 서비스 로직 수정
- 응답 DTO (`PostListResponseDTO`, `PostDetailsResponseDTO`)에 필드 반영

## 💖리뷰 요청사항
> 특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

- 게시글 리스트 조회 시 성능 이슈 없도록 쿼리 최적화한 부분 확인 부탁드립니다.
- DTO 변경이 기존 API 응답 스펙에 문제 없는지 검토 부탁드립니다!
