### PR TITLE
refactor: 로그인/비회원 권한 분기 및 좋아요 쿼리 테이블 수정

### DIFF
--- a/src/main/java/org/scoula/community/comment/controller/CommentApiController.java
+++ b/src/main/java/org/scoula/community/comment/controller/CommentApiController.java
@@ -5,11 +5,14 @@ import io.swagger.annotations.ApiOperation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.scoula.auth.exception.AccessDeniedException;
 import org.scoula.community.comment.dto.CommentCreateRequestDTO;
 import org.scoula.community.comment.dto.CommentResponseDTO;
 import org.scoula.community.comment.service.CommentService;
 import org.scoula.response.ApiResponse;
 import org.scoula.response.ResponseCode;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -48,21 +51,30 @@ public class CommentApiController {
     @ApiOperation(value = "댓글 생성", notes = "새 댓글을 등록합니다.")
     @PostMapping("")
     public ApiResponse<CommentResponseDTO> create(
-            @RequestBody CommentCreateRequestDTO commentCreateRequestDTO) {
+            @RequestBody CommentCreateRequestDTO commentCreateRequestDTO, @AuthenticationPrincipal UserDetails user) {
+        if (user == null) {
+            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
+        }
         CommentResponseDTO created = commentService.create(commentCreateRequestDTO);
         return ApiResponse.success(ResponseCode.COMMENT_CREATE_SUCCESS, created);
     }
 
     @ApiOperation(value = "댓글 삭제", notes = "commentId에 해당하는 댓글을 삭제합니다.")
     @DeleteMapping("/{commentId}")
-    public ApiResponse<Void> delete(@PathVariable Long commentId) {
+    public ApiResponse<Void> delete(@PathVariable Long commentId, @AuthenticationPrincipal UserDetails user) {
+        if (user == null) {
+            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
+        }
         commentService.delete(commentId);
         return ApiResponse.success(ResponseCode.COMMENT_DELETE_SUCCESS);
     }
 
     @ApiOperation(value = "내가 쓴 댓글 조회", notes = "현재 로그인한 사용자가 작성한 댓글 목록을 조회합니다.")
     @GetMapping("/my")
-    public ApiResponse<List<CommentResponseDTO>> getMyComments() {
+    public ApiResponse<List<CommentResponseDTO>> getMyComments(@AuthenticationPrincipal UserDetails user) {
+        if (user == null) {
+            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
+        }
         return ApiResponse.success(ResponseCode.COMMENT_LIST_SUCCESS,  commentService.getMyComments());
     }
 }

--- a/src/main/java/org/scoula/community/scrap/controller/ScrapApiController.java
+++ b/src/main/java/org/scoula/community/scrap/controller/ScrapApiController.java
@@ -5,12 +5,15 @@ import io.swagger.annotations.ApiOperation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.scoula.auth.exception.AccessDeniedException;
 import org.scoula.community.post.dto.PostListResponseDTO;
 import org.scoula.community.scrap.dto.ScrapCountResponseDTO;
 import org.scoula.community.scrap.dto.ScrapResponseDTO;
 import org.scoula.community.scrap.service.ScrapService;
 import org.scoula.response.ApiResponse;
 import org.scoula.response.ResponseCode;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -38,7 +41,10 @@ public class ScrapApiController {
 
     @ApiOperation(value = "내 스크랩 목록 조회", notes = "현재 사용자가 스크랩한 게시글 목록을 조회합니다.")
     @GetMapping("/my")
-    public ApiResponse<List<PostListResponseDTO>> getMyScrapList() {
+    public ApiResponse<List<PostListResponseDTO>> getMyScrapList(@AuthenticationPrincipal UserDetails user) {
+        if (user == null) {
+            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
+        }
         return ApiResponse.success(ResponseCode.SCRAP_LIST_SUCCESS, scrapService.getMyScrapList());
     }
 

--- a/src/main/java/org/scoula/response/ResponseCode.java
+++ b/src/main/java/org/scoula/response/ResponseCode.java
@@ -31,7 +31,7 @@ public enum ResponseCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근이 거부되었습니다."),
-
+    UNAUTHORIZED_USER(HttpStatus.FORBIDDEN, "로그인이 필요합니다."),
     /**
      * SMS response
      */

--- a/src/main/java/org/scoula/security/config/SecurityConfig.java
+++ b/src/main/java/org/scoula/security/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.scoula.security.handler.LoginSuccessHandler;
 import org.scoula.security.service.CustomUserDetailsService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -45,19 +46,47 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http
                 .csrf().disable()
                 .authorizeRequests()
-                .antMatchers("/api/auth/**","/api/sms/**","/api/validation/**" ,"/api/signup", "/resources/**",
-                        "/swagger-ui.html",
-                        "/swagger-ui/**",
-                        "/v2/api-docs",
-                        "/swagger-resources/**",
-                        "/webjars/**").permitAll()
+                // 완전 공개 API (비회원 접근 가능)
+                .antMatchers("/api/auth/**", "/api/sms/**", "/api/validation/**", "/api/signup",
+                        "/resources/**", "/swagger-ui.html", "/swagger-ui/**",
+                        "/v2/api-docs", "/swagger-resources/**", "/webjars/**").permitAll()
+
+                // 비회원도 접근 가능한 챗봇 및 커뮤니티 기능
+                .antMatchers("/api/chatbot/**").permitAll()                          // 챗봇 (비회원도 금융 질문 가능)
+                .antMatchers("/api/posts/hot").permitAll()                           // 핫 게시물 조회
+                .antMatchers("/api/posts/board/{boardId}").permitAll()               // 게시판별 게시물 조회
+                .antMatchers("/api/posts/board/{boardId}/hot").permitAll()           // 게시판별 핫 게시물
+                .antMatchers("/api/board").permitAll()                               // 게시판 목록 조회
+                .antMatchers(HttpMethod.GET, "/api/posts").permitAll()               // 게시물 목록 조회 (GET만)
+                .antMatchers(HttpMethod.GET, "/api/posts/{id}").permitAll()          // 개별 게시물 읽기
+
+                // 댓글 조회 (비회원 접근 가능)
+                .antMatchers(HttpMethod.GET, "/api/comments/{commentId}").permitAll()           // 댓글 단건 조회
+                .antMatchers(HttpMethod.GET, "/api/comments/parent/{parentCommentId}").permitAll() // 부모댓글+대댓글 조회
+                .antMatchers(HttpMethod.GET, "/api/comments/post/{postId}").permitAll()         // 게시글 댓글 리스트
+
+                // 금융 상품 비교/요약 (비회원 접근 가능)
+                .antMatchers("/api/chat/compare").permitAll()                        // 금융 상품 비교
+                .antMatchers("/api/chat/summary").permitAll()                        // 금융 상품 요약
+
+                // 회원만 접근 가능한 개인화 기능
+                .antMatchers("/api/post-like/**").authenticated()                    // 좋아요 기능
+                .antMatchers("/api/scraps/**").authenticated()                       // 스크랩 기능
+                .antMatchers("/api/posts/my").authenticated()                        // ⭐ 내가 쓴 글 (회원 전용)
+                .antMatchers("/api/comments/my").authenticated()                     // ⭐ 내가 쓴 댓글 (회원 전용)
+                .antMatchers(HttpMethod.POST, "/api/posts/**").authenticated()       // 게시물 작성
+                .antMatchers(HttpMethod.PUT, "/api/posts/**").authenticated()        // 게시물 수정
+                .antMatchers(HttpMethod.DELETE, "/api/posts/**").authenticated()     // 게시물 삭제
+                .antMatchers(HttpMethod.POST, "/api/comments/**").authenticated()    // 댓글 작성
+                .antMatchers(HttpMethod.PUT, "/api/comments/**").authenticated()     // 댓글 수정
+                .antMatchers(HttpMethod.DELETE, "/api/comments/**").authenticated()  // 댓글 삭제
+
                 .anyRequest().authenticated()
                 .and()
                 .logout().disable()
-                // JWT 인증필터
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterAt(loginFilter, UsernamePasswordAuthenticationFilter.class)
-                .sessionManagement().disable(); // JWT 사용 시 세션 미사용
+                .sessionManagement().disable();
     }
 
     // 사용자 정의 인증 서비스 + 암호화 설정

--- a/src/main/resources/org/scoula/community/postlike/mapper/PostLikeMapper.xml
+++ b/src/main/resources/org/scoula/community/postlike/mapper/PostLikeMapper.xml
@@ -38,7 +38,7 @@
     </select>
     <select id="existsByPostIdAndMemberId" resultType="java.lang.Boolean">
         SELECT COUNT(*) > 0
-        FROM scrap
-        WHERE post_id = #{postId} AND member_id = #{memberId}
+        FROM post_like
+        WHERE post_id = #{postId} AND member_id = #{memberId} AND is_liked = true
     </select>
 </mapper>


### PR DESCRIPTION
## #️⃣연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요.

- close: #53 

## 🪄작업 내용
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
>뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- 로그인 상태와 비회원 상태에 따른 권한 분기 처리 개선
- 좋아요 기능 관련 MyBatis 쿼리에서 scrap 테이블 → post_like 테이블로 수정
- AccessDeniedException 커스텀 예외 및 ResponseCode 추가

## 💖리뷰 요청사항
>특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

- 예외 처리 핸들러 구조 및 커스텀 예외 설계 적절성
- MyBatis 쿼리 수정이 잘 적용되었는지 확인 부탁드립니다
- 권한 분기 로직에 누락된 부분이나 추가 개선점이 있으면 알려주세요
