### PR TITLE
refactor: community 유저 예외 처리

### DIFF
--- a/src/main/java/org/scoula/community/comment/controller/CommentApiController.java
+++ b/src/main/java/org/scoula/community/comment/controller/CommentApiController.java
@@ -51,30 +51,21 @@ public class CommentApiController {
     @ApiOperation(value = "댓글 생성", notes = "새 댓글을 등록합니다.")
     @PostMapping("")
     public ApiResponse<CommentResponseDTO> create(
-            @RequestBody CommentCreateRequestDTO commentCreateRequestDTO, @AuthenticationPrincipal UserDetails user) {
-        if (user == null) {
-            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
-        }
+            @RequestBody CommentCreateRequestDTO commentCreateRequestDTO) {
         CommentResponseDTO created = commentService.create(commentCreateRequestDTO);
         return ApiResponse.success(ResponseCode.COMMENT_CREATE_SUCCESS, created);
     }
 
     @ApiOperation(value = "댓글 삭제", notes = "commentId에 해당하는 댓글을 삭제합니다.")
     @DeleteMapping("/{commentId}")
-    public ApiResponse<Void> delete(@PathVariable Long commentId, @AuthenticationPrincipal UserDetails user) {
-        if (user == null) {
-            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
-        }
+    public ApiResponse<Void> delete(@PathVariable Long commentId) {
         commentService.delete(commentId);
         return ApiResponse.success(ResponseCode.COMMENT_DELETE_SUCCESS);
     }
 
     @ApiOperation(value = "내가 쓴 댓글 조회", notes = "현재 로그인한 사용자가 작성한 댓글 목록을 조회합니다.")
     @GetMapping("/my")
-    public ApiResponse<List<CommentResponseDTO>> getMyComments(@AuthenticationPrincipal UserDetails user) {
-        if (user == null) {
-            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
-        }
+    public ApiResponse<List<CommentResponseDTO>> getMyComments() {
         return ApiResponse.success(ResponseCode.COMMENT_LIST_SUCCESS,  commentService.getMyComments());
     }
 }

--- a/src/main/java/org/scoula/community/comment/service/CommentServiceImpl.java
+++ b/src/main/java/org/scoula/community/comment/service/CommentServiceImpl.java
@@ -189,7 +189,14 @@ public class CommentServiceImpl implements CommentService {
 
 
     private Long getCurrentUserIdAsLong() {
-        String email = SecurityContextHolder.getContext().getAuthentication().getName();
-        return memberMapper.getMemberIdByEmail(email); // 👈 이메일로 memberId 조회하는 쿼리 필요
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()
+                || authentication.getPrincipal().equals("anonymousUser")) {
+            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
+        }
+
+        String email = authentication.getName();
+        return memberMapper.getMemberIdByEmail(email);
     }
 }

--- a/src/main/java/org/scoula/community/commentlike/service/CommentLikeServiceImpl.java
+++ b/src/main/java/org/scoula/community/commentlike/service/CommentLikeServiceImpl.java
@@ -26,6 +26,9 @@ public class CommentLikeServiceImpl implements CommentLikeService {
     @Transactional
     public boolean toggleLike(Long commentId) {
         Long memberId = getCurrentUserIdAsLong();
+        if (!commentMapper.existsById(commentId)) {
+            throw new CommentNotFoundException(ResponseCode.COMMENT_NOT_FOUND);
+        }
 
         CommentLikeVO like = commentLikeMapper.findByCommentIdAndMemberId(commentId, memberId);
 
@@ -60,7 +63,14 @@ public class CommentLikeServiceImpl implements CommentLikeService {
         return like != null && like.isLiked();
     }
     private Long getCurrentUserIdAsLong() {
-        String email = SecurityContextHolder.getContext().getAuthentication().getName();
-        return memberMapper.getMemberIdByEmail(email); // 👈 이메일로 memberId 조회하는 쿼리 필요
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()
+                || authentication.getPrincipal().equals("anonymousUser")) {
+            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
+        }
+
+        String email = authentication.getName();
+        return memberMapper.getMemberIdByEmail(email);
     }
 }

--- a/src/main/java/org/scoula/community/post/controller/PostApiController.java
+++ b/src/main/java/org/scoula/community/post/controller/PostApiController.java
@@ -47,10 +47,7 @@ public class PostApiController {
 
     @ApiOperation(value = "게시글 생성", notes = "새 게시글을 등록합니다. 파일 첨부 가능합니다.")
     @PostMapping(value = "")
-    public ApiResponse<PostDetailsResponseDTO> create(@RequestBody PostCreateRequestDTO postCreateRequestDTO, @AuthenticationPrincipal UserDetails user){
-        if (user == null) {
-            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
-        }
+    public ApiResponse<PostDetailsResponseDTO> create(@RequestBody PostCreateRequestDTO postCreateRequestDTO){
         PostDetailsResponseDTO created = postService.create(postCreateRequestDTO);
         return ApiResponse.success(ResponseCode.POST_CREATE_SUCCESS, created);
     }
@@ -66,20 +63,14 @@ public class PostApiController {
     @ApiOperation(value = "게시글 수정", notes = "기존 게시글을 수정합니다. 추가 파일 첨부 가능합니다.")
     @PutMapping(value = "/{postId}")
     public ApiResponse<PostDetailsResponseDTO> update(
-            @PathVariable Long postId, @RequestBody PostUpdateRequestDTO postUpdateRequestDTO, @AuthenticationPrincipal UserDetails user) {
-        if (user == null) {
-            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
-        }
+            @PathVariable Long postId, @RequestBody PostUpdateRequestDTO postUpdateRequestDTO) {
         PostDetailsResponseDTO updated = postService.update(postId, postUpdateRequestDTO);
         return ApiResponse.success(ResponseCode.POST_UPDATE_SUCCESS, updated);
     }
 
     @ApiOperation(value = "게시글 삭제", notes = "postId에 해당하는 게시글을 삭제합니다.")
     @DeleteMapping("/{postId}")
-    public ApiResponse<Void> delete(@PathVariable Long postId, @AuthenticationPrincipal UserDetails user) {
-        if (user == null) {
-            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
-        }
+    public ApiResponse<Void> delete(@PathVariable Long postId) {
         postService.delete(postId);
         return ApiResponse.success(ResponseCode.POST_DELETE_SUCCESS);
     }
@@ -102,10 +93,7 @@ public class PostApiController {
 
     @ApiOperation(value = "내가 쓴 글 조회", notes = "현재 로그인한 사용자가 작성한 게시글 목록을 조회합니다.")
     @GetMapping("/my")
-    public ApiResponse<List<PostListResponseDTO>> getMyPosts(@AuthenticationPrincipal UserDetails user) {
-        if (user == null) {
-            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
-        }
+    public ApiResponse<List<PostListResponseDTO>> getMyPosts() {
         return ApiResponse.success(ResponseCode.POST_LIST_SUCCESS, postService.getMyPosts());
     }
     @ApiOperation(value = "게시판별 핫게시물 조회 (전날 기준)", notes = "전날 작성된 게시물 중 좋아요 순으로 정렬된 핫게시물을 조회합니다.")

--- a/src/main/java/org/scoula/community/post/service/PostServiceImpl.java
+++ b/src/main/java/org/scoula/community/post/service/PostServiceImpl.java
@@ -428,15 +428,15 @@ public class PostServiceImpl implements PostService {
 //    }
 
     private Long getCurrentUserIdAsLong() {
-        String email = SecurityContextHolder.getContext().getAuthentication().getName();
-        log.info("email: {}", email);
-        return memberMapper.getMemberIdByEmail(email);
-    }
-    private void validateTags(String categoryTag, String productTag) {
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        if (productTag != null && !ProductTag.isValidCode(productTag)) {
-            throw new InvalidTagException(ResponseCode.INVALID_PRODUCT_TAG);
+        if (authentication == null || !authentication.isAuthenticated()
+                || authentication.getPrincipal().equals("anonymousUser")) {
+            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
         }
+
+        String email = authentication.getName();
+        return memberMapper.getMemberIdByEmail(email);
     }
     private void validatePostExists(Long postId) {
         if (!postMapper.existsById(postId)) {

--- a/src/main/java/org/scoula/community/postlike/service/PostLikeServiceImpl.java
+++ b/src/main/java/org/scoula/community/postlike/service/PostLikeServiceImpl.java
@@ -90,7 +90,14 @@ public class PostLikeServiceImpl implements PostLikeService {
         return postLikeMapper.countByPostId(postId);
     }
     private Long getCurrentUserIdAsLong() {
-        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()
+                || authentication.getPrincipal().equals("anonymousUser")) {
+            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
+        }
+
+        String email = authentication.getName();
         return memberMapper.getMemberIdByEmail(email);
     }
 

--- a/src/main/java/org/scoula/community/scrap/controller/ScrapApiController.java
+++ b/src/main/java/org/scoula/community/scrap/controller/ScrapApiController.java
@@ -41,10 +41,7 @@ public class ScrapApiController {
 
     @ApiOperation(value = "내 스크랩 목록 조회", notes = "현재 사용자가 스크랩한 게시글 목록을 조회합니다.")
     @GetMapping("/my")
-    public ApiResponse<List<PostListResponseDTO>> getMyScrapList(@AuthenticationPrincipal UserDetails user) {
-        if (user == null) {
-            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
-        }
+    public ApiResponse<List<PostListResponseDTO>> getMyScrapList() {
         return ApiResponse.success(ResponseCode.SCRAP_LIST_SUCCESS, scrapService.getMyScrapList());
     }
 

--- a/src/main/java/org/scoula/security/config/SecurityConfig.java
+++ b/src/main/java/org/scoula/security/config/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http
                 .csrf().disable()
                 .authorizeRequests()
-          
+
                 // 완전 공개 API (비회원 접근 가능)
                 .antMatchers("/api/auth/**", "/api/sms/**", "/api/validation/**", "/api/signup",
                         "/api/wmti/questions", "/resources/**", "/swagger-ui.html", "/swagger-ui/**",
@@ -79,7 +79,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers(HttpMethod.PUT, "/api/posts/**").authenticated()        // 게시물 수정
                 .antMatchers(HttpMethod.DELETE, "/api/posts/**").authenticated()     // 게시물 삭제
                 .antMatchers(HttpMethod.POST, "/api/comments/**").authenticated()    // 댓글 작성
-                .antMatchers(HttpMethod.PUT, "/api/comments/**").authenticated()     // 댓글 수정
                 .antMatchers(HttpMethod.DELETE, "/api/comments/**").authenticated()  // 댓글 삭제
 
                 .anyRequest().authenticated()


### PR DESCRIPTION
## #️⃣연관된 이슈
> PR과 연관된 이슈 번호를 작성해주세요. 

- close: #63 

## 🪄작업 내용
> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- 인증이 필요한 API(`/api/posts/scrap/my`)에서 401 오류가 발생하는 현상 수정
- `@AuthenticationPrincipal` 없이도 인증 통과하는 API(`/api/posts/likes/me`)와 비교하여 원인 분석
- Spring Security 필터 및 ArgumentResolver 설정 검토 및 수정
- 인증이 필요한 API의 인증 처리 방식 일관성 확보

## 💖리뷰 요청사항
> 특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

- 동일한 인증 방식인데도 일부 API만 401을 뱉는 문제의 원인을 추적하는 데 시간이 좀 걸렸습니다 🥲
- 인증 흐름 타는 로직 다시 한 번 확인해주시면 감사하겠습니다 🙏
- 혹시 더 안전하게 처리하는 방식이 있다면 피드백 주세요!