### PR TITLE
refactor: 권한 수정

### DIFF
--- a/src/main/java/org/scoula/community/comment/service/CommentServiceImpl.java
+++ b/src/main/java/org/scoula/community/comment/service/CommentServiceImpl.java
@@ -34,6 +34,11 @@ public class CommentServiceImpl implements CommentService {
     @Transactional
     public CommentResponseDTO create(CommentCreateRequestDTO commentCreateRequestDTO) {
         log.info("create........." + commentCreateRequestDTO);
+        Long memberId = getCurrentUserIdAsLong();
+        if (memberId == null) {
+            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
+        }
+
         if (!postMapper.existsById(commentCreateRequestDTO.getPostId())) {
             throw new PostNotFoundException(ResponseCode.POST_NOT_FOUND);
         }
@@ -48,7 +53,7 @@ public class CommentServiceImpl implements CommentService {
         }
 
         CommentVO vo = commentCreateRequestDTO.toVo();
-        vo.setMemberId(getCurrentUserIdAsLong());
+        vo.setMemberId(memberId);
         commentMapper.create(vo);
         postMapper.incrementCommentCount(vo.getPostId());
 
@@ -80,6 +85,10 @@ public class CommentServiceImpl implements CommentService {
             throw new CommentNotFoundException(ResponseCode.COMMENT_NOT_FOUND);
         }
         Long memberId = getCurrentUserIdAsLong();
+        if (memberId == null) {
+            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
+        }
+
         if (comment.getMemberId()!= memberId) {
             throw new AccessDeniedException(ResponseCode.ACCESS_DENIED);
         }
@@ -166,9 +175,12 @@ public class CommentServiceImpl implements CommentService {
     @Override
     public List<CommentResponseDTO> getMyComments() {
         log.info("getMyComments..........");
-        Long currentUserId = getCurrentUserIdAsLong();
+        Long memberId = getCurrentUserIdAsLong();
+        if (memberId == null) {
+            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
+        }
 
-        List<CommentVO> comments = commentMapper.getCommentsByMemberId(currentUserId);
+        List<CommentVO> comments = commentMapper.getCommentsByMemberId(memberId);
         if (comments == null || comments.isEmpty()) {
             return List.of();
         }
@@ -177,12 +189,12 @@ public class CommentServiceImpl implements CommentService {
                 .map(CommentVO::getCommentId)
                 .toList();
 
-        List<Long> likedCommentIds = commentLikeMapper.findLikedCommentIdsByMemberIdAndCommentIds(currentUserId, commentIds);
+        List<Long> likedCommentIds = commentLikeMapper.findLikedCommentIdsByMemberIdAndCommentIds(memberId, commentIds);
 
         return comments.stream()
                 .map(comment -> {
                     boolean isLiked = likedCommentIds.contains(comment.getCommentId());
-                    return CommentResponseDTO.of(comment, isLiked, memberMapper.getNicknameByMemberId(currentUserId));
+                    return CommentResponseDTO.of(comment, isLiked, memberMapper.getNicknameByMemberId(memberId));
                 })
                 .toList();
     }
@@ -193,7 +205,7 @@ public class CommentServiceImpl implements CommentService {
 
         if (authentication == null || !authentication.isAuthenticated()
                 || authentication.getPrincipal().equals("anonymousUser")) {
-            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
+            return null;
         }
 
         String email = authentication.getName();

--- a/src/main/java/org/scoula/community/commentlike/service/CommentLikeServiceImpl.java
+++ b/src/main/java/org/scoula/community/commentlike/service/CommentLikeServiceImpl.java
@@ -26,6 +26,9 @@ public class CommentLikeServiceImpl implements CommentLikeService {
     @Transactional
     public boolean toggleLike(Long commentId) {
         Long memberId = getCurrentUserIdAsLong();
+        if (memberId == null) {
+            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
+        }
         if (!commentMapper.existsById(commentId)) {
             throw new CommentNotFoundException(ResponseCode.COMMENT_NOT_FOUND);
         }
@@ -67,7 +70,7 @@ public class CommentLikeServiceImpl implements CommentLikeService {
 
         if (authentication == null || !authentication.isAuthenticated()
                 || authentication.getPrincipal().equals("anonymousUser")) {
-            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
+            return null;
         }
 
         String email = authentication.getName();

--- a/src/main/java/org/scoula/community/postlike/service/PostLikeServiceImpl.java
+++ b/src/main/java/org/scoula/community/postlike/service/PostLikeServiceImpl.java
@@ -30,6 +30,9 @@ public class PostLikeServiceImpl implements PostLikeService {
     public boolean toggleLike(Long postId) {
         validatePostExists(postId);
         Long memberId = getCurrentUserIdAsLong();
+        if (memberId == null) {
+            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
+        }
 
         PostLikeVO like = postLikeMapper.findByPostIdAndMemberId(postId, memberId);
 
@@ -94,7 +97,7 @@ public class PostLikeServiceImpl implements PostLikeService {
 
         if (authentication == null || !authentication.isAuthenticated()
                 || authentication.getPrincipal().equals("anonymousUser")) {
-            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
+            return null;
         }
 
         String email = authentication.getName();

--- a/src/main/java/org/scoula/community/scrap/service/ScrapServiceImpl.java
+++ b/src/main/java/org/scoula/community/scrap/service/ScrapServiceImpl.java
@@ -33,6 +33,9 @@ public class ScrapServiceImpl implements ScrapService {
     public ScrapResponseDTO toggleScrap(Long postId) {
         validatePostExists(postId);
         Long memberId = getCurrentUserIdAsLong();
+        if (memberId == null) {
+            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
+        }
         boolean isScraped;
 
         if (scrapMapper.existsScrap(postId, memberId)) {
@@ -67,6 +70,9 @@ public class ScrapServiceImpl implements ScrapService {
     @Override
     public List<PostListResponseDTO> getMyScrapList() {
         Long memberId = getCurrentUserIdAsLong();
+        if (memberId == null) {
+            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
+        }
 
         return scrapMapper.getScrapPostsByMemberId(memberId).stream()
                 .map(post -> {
@@ -111,7 +117,7 @@ public class ScrapServiceImpl implements ScrapService {
 
         if (authentication == null || !authentication.isAuthenticated()
                 || authentication.getPrincipal().equals("anonymousUser")) {
-            throw new AccessDeniedException(ResponseCode.UNAUTHORIZED_USER);
+            return null;
         }
 
         String email = authentication.getName();

--- a/src/main/java/org/scoula/security/config/SecurityConfig.java
+++ b/src/main/java/org/scoula/security/config/SecurityConfig.java
@@ -60,11 +60,14 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/api/board").permitAll()                               // 게시판 목록 조회
                 .antMatchers(HttpMethod.GET, "/api/posts").permitAll()               // 게시물 목록 조회 (GET만)
                 .antMatchers(HttpMethod.GET, "/api/posts/{id}").permitAll()          // 개별 게시물 읽기
+                .antMatchers(HttpMethod.GET, "/api/post-like/{postId}/count").permitAll()
+                .antMatchers(HttpMethod.GET, "/api/scraps/posts/{postId}/count").permitAll()
 
                 // 댓글 조회 (비회원 접근 가능)
                 .antMatchers(HttpMethod.GET, "/api/comments/{commentId}").permitAll()           // 댓글 단건 조회
                 .antMatchers(HttpMethod.GET, "/api/comments/parent/{parentCommentId}").permitAll() // 부모댓글+대댓글 조회
                 .antMatchers(HttpMethod.GET, "/api/comments/post/{postId}").permitAll()         // 게시글 댓글 리스트
+                .antMatchers(HttpMethod.GET, "/api/comment-like/{commentId}/count").permitAll()
 
                 // 금융 상품 비교/요약 (비회원 접근 가능)
                 .antMatchers("/api/chat/compare").permitAll()                        // 금융 상품 비교


### PR DESCRIPTION
## #️⃣연관된 이슈
> PR과 연관된 이슈 번호를 작성해주세요. ex) 

- close: #67 

## 🪄작업 내용
> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.  
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- Spring Security 권한 설정 수정  
- 비회원도 접근 가능한 API 엔드포인트에 permitAll() 적용  
- `/api/comment-like/{commentId}/count`, `/api/post-like/{postId}/count` API 비회원 접근 가능하도록 권한 조정  
- `getCurrentUserIdAsLong()` 메서드 수정으로 비회원일 경우 null 반환 처리 및 예외 최소화  
- 관련 테스트 및 권한 동작 검증  

## 💖리뷰 요청사항
> 특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

- 비회원과 회원 권한 구분 처리 부분  
- SecurityConfig의 permitAll 설정 적절성  
- getCurrentUserIdAsLong() null 처리 및 예외처리 로직 검토  
- 전체 API 권한 흐름과 보안성  
